### PR TITLE
Add support for Serde

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ rust:
 matrix:
   allow_failures:
   - rust: nightly
-  
+ 
+script: cargo test --all-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,12 @@ readme = "README.md"
 documentation = "https://docs.rs/ipnet"
 
 [dependencies]
+serde = { version = "1", optional = true }
+serde_derive = { version = "1", optional = true }
+
+[dev-dependencies]
+serde_test = "1"
+
+[features]
+default = []
+with-serde = ["serde", "serde_derive"]

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -40,6 +40,8 @@ use ipext::{IpAdd, IpSub, IpStep, IpAddrRange, Ipv4AddrRange, Ipv6AddrRange};
 /// let net: IpNet = "fd00::/32".parse().unwrap();
 /// assert_eq!(Ok(net.network()), "fd00::".parse());
 /// ```
+#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(untagged))]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum IpNet {
     V4(Ipv4Net),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,19 @@
 //! [`IpBitAnd`]: trait.IpBitAnd.html
 //! [`IpBitOr`]: trait.IpBitOr.html
 //! [`Emu128`]: struct.Emu128.html
+//!
+//! # Serde support
+//!
+//! This library comes with support for [serde](https://serde.rs) but it's
+//! not enabled by default. Use the `with-serde` [feature] to enable.
+//!
+//! [feature]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
+
+#[cfg(feature = "with-serde")]
+extern crate serde;
+#[cfg(feature = "with-serde")]
+#[macro_use]
+extern crate serde_derive;
 
 pub use self::emu128::Emu128;
 pub use self::ipext::{IpAdd, IpSub, IpBitAnd, IpBitOr, IpAddrRange, Ipv4AddrRange, Ipv6AddrRange};
@@ -65,3 +78,5 @@ mod emu128;
 mod ipext;
 mod ipnet;
 mod parser;
+#[cfg(feature = "with-serde")]
+mod with_serde;

--- a/src/with_serde.rs
+++ b/src/with_serde.rs
@@ -1,0 +1,74 @@
+use {Ipv4Net, Ipv6Net};
+use serde::{self, Serialize, Deserialize, Serializer, Deserializer};
+
+impl<'de> Deserialize<'de> for Ipv4Net {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for Ipv4Net {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Ipv6Net {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for Ipv6Net {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate serde_test;
+
+    use {IpNet, Ipv4Net, Ipv6Net};
+    use self::serde_test::{assert_tokens, Configure, Token};
+
+    #[test]
+    fn test_serialize_ipv4_net() {
+        let net_str = "10.1.1.0/24";
+        let net: Ipv4Net = net_str.parse().unwrap();
+        assert_tokens(&net.readable(), &[Token::Str(net_str)]);
+    }
+
+    #[test]
+    fn test_serialize_ipnet_v4() {
+        let net_str = "10.1.1.0/24";
+        let net: IpNet = net_str.parse().unwrap();
+        assert_tokens(&net.readable(), &[Token::Str(net_str)]);
+    }
+
+    #[test]
+    fn test_serialize_ipv6_net() {
+        let net_str = "fd00::/32";
+        let net: Ipv6Net = net_str.parse().unwrap();
+        assert_tokens(&net.readable(), &[Token::Str(net_str)]);
+    }
+
+    #[test]
+    fn test_serialize_ipnet_v6() {
+        let net_str = "fd00::/32";
+        let net: IpNet = net_str.parse().unwrap();
+        assert_tokens(&net.readable(), &[Token::Str(net_str)]);
+    }
+}


### PR DESCRIPTION
Adds support for `serde` behind the `with-serde` feature. The feature is not enabled by default.

/cc @krisprice