### PR TITLE
Rename `with-serde` feature to `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,10 @@ readme = "README.md"
 documentation = "https://docs.rs/ipnet"
 
 [dependencies]
-serde = { version = "1", optional = true }
-serde_derive = { version = "1", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_test = "1"
 
 [features]
-default = []
-with-serde = ["serde", "serde_derive"]
+with-serde = ["serde"] # Compatibility shim for 1.1.0. Use `serde` instead.

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -40,8 +40,8 @@ use ipext::{IpAdd, IpSub, IpStep, IpAddrRange, Ipv4AddrRange, Ipv6AddrRange};
 /// let net: IpNet = "fd00::/32".parse().unwrap();
 /// assert_eq!(Ok(net.network()), "fd00::".parse());
 /// ```
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "with-serde", serde(untagged))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum IpNet {
     V4(Ipv4Net),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,15 +59,13 @@
 //! # Serde support
 //!
 //! This library comes with support for [serde](https://serde.rs) but it's
-//! not enabled by default. Use the `with-serde` [feature] to enable.
+//! not enabled by default. Use the `serde` [feature] to enable.
 //!
 //! [feature]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 
-#[cfg(feature = "with-serde")]
-extern crate serde;
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 pub use self::emu128::Emu128;
 pub use self::ipext::{IpAdd, IpSub, IpBitAnd, IpBitOr, IpAddrRange, Ipv4AddrRange, Ipv6AddrRange};
@@ -78,5 +76,5 @@ mod emu128;
 mod ipext;
 mod ipnet;
 mod parser;
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 mod with_serde;


### PR DESCRIPTION
This change is backwards compatible. The Rust API Guidelines
recommend that we use `serde` as the name of the feature.