### PR TITLE
Faster iter

### DIFF
--- a/src/ipext.rs
+++ b/src/ipext.rs
@@ -486,7 +486,11 @@ impl Iterator for Ipv4AddrRange {
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         let n = n as u64;
         let count = self.count_u64();
-        if n >= count { None }
+        if n >= count {
+            self.end.replace_zero();
+            self.start = Ipv4Addr::new(0, 0, 0, 1);
+            None
+        }
         else if n == count - 1 {
             let end = self.end.replace_zero();
             self.start = Ipv4Addr::new(0, 0, 0, 1);
@@ -555,7 +559,11 @@ impl Iterator for Ipv6AddrRange {
         let n = n as u128;
         if self.can_count() {
             let count = self.count_u128();
-            if n >= count { None }
+            if n >= count {
+                self.end.replace_zero();
+                self.start = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
+                None
+            }
             else if n == count - 1 {
                 let end = self.end.replace_zero();
                 self.start = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
@@ -753,10 +761,13 @@ mod tests {
         assert_eq!(i.clone().nth(3), Some(Ipv4Addr::from_str("10.0.0.3").unwrap()));
         assert_eq!(i.clone().nth(4), None);
         assert_eq!(i.clone().nth(99), None);
-        let mut i = i.clone();
-        assert_eq!(i.nth(1), Some(Ipv4Addr::from_str("10.0.0.1").unwrap()));
-        assert_eq!(i.nth(1), Some(Ipv4Addr::from_str("10.0.0.3").unwrap()));
-        assert_eq!(i.nth(0), None);
+        let mut i2 = i.clone();
+        assert_eq!(i2.nth(1), Some(Ipv4Addr::from_str("10.0.0.1").unwrap()));
+        assert_eq!(i2.nth(1), Some(Ipv4Addr::from_str("10.0.0.3").unwrap()));
+        assert_eq!(i2.nth(0), None);
+        let mut i3 = i.clone();
+        assert_eq!(i3.nth(99), None);
+        assert_eq!(i3.next(), None);
 
         let i = Ipv6AddrRange::new(
             Ipv6Addr::from_str("fd00::").unwrap(),
@@ -766,9 +777,12 @@ mod tests {
         assert_eq!(i.clone().nth(3), Some(Ipv6Addr::from_str("fd00::3").unwrap()));
         assert_eq!(i.clone().nth(4), None);
         assert_eq!(i.clone().nth(99), None);
-        let mut i = i.clone();
-        assert_eq!(i.nth(1), Some(Ipv6Addr::from_str("fd00::1").unwrap()));
-        assert_eq!(i.nth(1), Some(Ipv6Addr::from_str("fd00::3").unwrap()));
-        assert_eq!(i.nth(0), None);
+        let mut i2 = i.clone();
+        assert_eq!(i2.nth(1), Some(Ipv6Addr::from_str("fd00::1").unwrap()));
+        assert_eq!(i2.nth(1), Some(Ipv6Addr::from_str("fd00::3").unwrap()));
+        assert_eq!(i2.nth(0), None);
+        let mut i3 = i.clone();
+        assert_eq!(i3.nth(99), None);
+        assert_eq!(i3.next(), None);
     }
 }

--- a/src/ipext.rs
+++ b/src/ipext.rs
@@ -374,7 +374,7 @@ impl Iterator for Ipv4AddrRange {
             },
             Some(Equal) => {
                 self.end.replace_zero();
-                Some(self.start)
+                Some(mem::replace(&mut self.start, Ipv4Addr::new(0, 0, 0, 1)))
             },
             _ => None,
         }
@@ -392,7 +392,7 @@ impl Iterator for Ipv6AddrRange {
             },
             Some(Equal) => {
                 self.end.replace_zero();
-                Some(self.start)
+                Some(mem::replace(&mut self.start, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
             },
             _ => None,
         }
@@ -494,5 +494,16 @@ mod tests {
             IpAddr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe").unwrap(),
             IpAddr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
         ]);
+
+        let zero4 = Ipv4Addr::from_str("0.0.0.0").unwrap();
+        let zero6 = Ipv6Addr::from_str("::").unwrap();
+
+        let mut i = Ipv4AddrRange::new(zero4, zero4);
+        assert_eq!(Some(zero4), i.next());
+        assert_eq!(None, i.next());
+
+        let mut i = Ipv6AddrRange::new(zero6, zero6);
+        assert_eq!(Some(zero6), i.next());
+        assert_eq!(None, i.next());
     }
 }

--- a/src/ipext.rs
+++ b/src/ipext.rs
@@ -355,17 +355,6 @@ impl Ipv4AddrRange {
             _ => 0,
         }
     }
-
-    // fn try_count(&self) -> Option<u32> {
-    //     match self.start.partial_cmp(&self.end) {
-    //         Some(Less) => {
-    //             let count = self.end.saturating_sub(self.start);
-    //             count.checked_add(1)
-    //         },
-    //         Some(Equal) => Some(1),
-    //         _ => Some(0)
-    //     }
-    // }
 }
 
 impl Ipv6AddrRange {
@@ -394,17 +383,6 @@ impl Ipv6AddrRange {
         self.start != Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)
         || self.end != Ipv6Addr::new(0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
     }
-
-    // fn try_count_u128(&self) -> Option<u128> {
-    //     match self.start.partial_cmp(&self.end) {
-    //         Some(Less) => {
-    //             let count = self.end.saturating_sub(self.start);
-    //             count.checked_add(1)
-    //         },
-    //         Some(Equal) => Some(1),
-    //         _ => Some(0)
-    //     }
-    // }
 }
 
 impl Iterator for IpAddrRange {

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering::{Less, Equal};
 use std::convert::From;
 use std::error::Error;
 use std::fmt;
+use std::iter::FusedIterator;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::option::Option::{Some, None};
 
@@ -1444,6 +1445,10 @@ impl Iterator for Ipv6Subnets {
         }
     }
 }
+
+impl FusedIterator for IpSubnets {}
+impl FusedIterator for Ipv4Subnets {}
+impl FusedIterator for Ipv6Subnets {}
 
 // Generic function for merging a vector of intervals.
 fn merge_intervals<T: Copy + Ord>(mut intervals: Vec<(T, T)>) -> Vec<(T, T)> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -54,7 +54,7 @@ impl<'a> Parser<'a> {
     }
 
     // Return result of first successful parser
-    fn read_or<T>(&mut self, parsers: &mut [Box<FnMut(&mut Parser) -> Option<T> + 'static>])
+    fn read_or<T>(&mut self, parsers: &mut [Box<dyn FnMut(&mut Parser) -> Option<T> + 'static>])
                -> Option<T> {
         for pf in parsers {
             if let Some(r) = self.read_atomically(|p: &mut Parser| pf(p)) {


### PR DESCRIPTION
This includes the changes in #12 

As of now this is ~~not complete~~ pending comments/review but otherwise complete, however I wanted to make sure the changes so far make sense.

I added a `count_u64` (for Ipv4AddrRange) and `count_u128` (for Ipv6AddrRange) method which I'm using internally. `count_u64` is intended to never overflow or panic since IPv4 is 32-bits wide. On the other hand, `count_u128` may overflow or panic since `u128::MAX - u128::MIN + 1` overflows u128. For this reason, I also added  a method on Ipv6AddrRange named `can_count_u128` to indicate if `count_u128` would overflow.

In addition to what I have now, `FusedIterator` can be implemented for all three range types, as well as `DoubleEndedIterator`.

I thought about implementing `ExactSizeIterator` however this doesn't seem to be viable since the size may overflow usize (even for Ipv4AddrRange, size may overflow on 32-bit systems). If there is some kind of precedent in the language that indicates it's actually okay to implement `ExactSizeIterator`, then I can do so.