### PR TITLE
Fix Error::description() deprecation warning

### DIFF
--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -113,15 +113,11 @@ pub struct PrefixLenError;
 
 impl fmt::Display for PrefixLenError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str(self.description())
+        fmt.write_str("invalid IP prefix length")
     }
 }
 
-impl Error for PrefixLenError {
-    fn description(&self) -> &str {
-        "invalid IP prefix length"
-    }
-}
+impl Error for PrefixLenError {}
 
 impl IpNet {
     /// Returns a copy of the network with the address truncated to the

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -338,12 +338,8 @@ pub struct AddrParseError(());
 
 impl fmt::Display for AddrParseError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str(self.description())
+        fmt.write_str("invalid IP address syntax")
     }
 }
 
-impl Error for AddrParseError {
-    fn description(&self) -> &str {
-        "invalid IP address syntax"
-    }
-}
+impl Error for AddrParseError {}


### PR DESCRIPTION
Deprecated since Rust 1.42.0, but does not require 1.42.0, because deprecation
has been prepared in https://github.com/rust-lang/rust/pull/50163
by providing a default implementation.