### PR TITLE
Add 'schemars' feature for deriving JSON schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,11 @@ documentation = "https://docs.rs/ipnet"
 
 [features]
 default = []
-# Implements "serde::Serialize" and "serde::Deserialize".
-serde = ["serde_crate"]
 # Implements "schemars::JsonSchema". Also implies "serde".
 json = ["serde", "schemars"]
 
 [dependencies]
-# "serde" is renamed to "serde_crate" to avoid a feature vs dependency
-# name conflict. For more context:
-# https://github.com/rust-lang/api-guidelines/discussions/180
-serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
+serde = { package = "serde", version = "1", features = ["derive"], optional = true }
 schemars = { version = "0.8", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,19 @@ categories = ["network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/ipnet"
 
+[features]
+default = []
+# Implements "serde::Serialize" and "serde::Deserialize".
+serde = ["serde_crate"]
+# Implements "schemars::JsonSchema". Also implies "serde".
+json = ["serde", "schemars"]
+
 [dependencies]
-serde = { version = "1", features = ["derive"], optional = true }
+# "serde" is renamed to "serde_crate" to avoid a feature vs dependency
+# name conflict. For more context:
+# https://github.com/rust-lang/api-guidelines/discussions/180
+serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
+schemars = { version = "0.8", optional = true }
 
 [dev-dependencies]
 serde_test = "1"

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -40,6 +40,7 @@ use ipext::{IpAdd, IpSub, IpStep, IpAddrRange, Ipv4AddrRange, Ipv6AddrRange};
 /// assert_eq!(Ok(net.network()), "fd00::".parse());
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "json", derive(schemars::JsonSchema))]
 pub enum IpNet {
     V4(Ipv4Net),
     V6(Ipv6Net),
@@ -70,6 +71,7 @@ pub enum IpNet {
 /// assert_eq!(Ok(net.network()), "10.1.1.0".parse());
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "json", derive(schemars::JsonSchema))]
 pub struct Ipv4Net {
     addr: Ipv4Addr,
     prefix_len: u8,
@@ -100,6 +102,7 @@ pub struct Ipv4Net {
 /// assert_eq!(Ok(net.network()), "fd00::".parse());
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "json", derive(schemars::JsonSchema))]
 pub struct Ipv6Net {
     addr: Ipv6Addr,
     prefix_len: u8,

--- a/src/ipnet_serde.rs
+++ b/src/ipnet_serde.rs
@@ -1,9 +1,9 @@
 use {IpNet, Ipv4Net, Ipv6Net};
 use std::fmt;
 use std::net::{Ipv4Addr, Ipv6Addr};
-use serde_crate::{self, Serialize, Deserialize, Serializer, Deserializer};
-use serde_crate::ser::SerializeTuple;
-use serde_crate::de::{EnumAccess, Error, VariantAccess, Visitor};
+use serde::{self, Serialize, Deserialize, Serializer, Deserializer};
+use serde::ser::SerializeTuple;
+use serde::de::{EnumAccess, Error, VariantAccess, Visitor};
 
 impl Serialize for IpNet {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -49,7 +49,6 @@ impl<'de> Deserialize<'de> for IpNet {
             struct EnumVisitor;
 
             #[derive(Serialize, Deserialize)]
-            #[serde(crate = "serde_crate")]
             enum IpNetKind {
                 V4,
                 V6,
@@ -118,7 +117,7 @@ impl<'de> Deserialize<'de> for Ipv4Net {
             deserializer.deserialize_str(IpAddrVisitor)
         } else {
             let b = <[u8; 5]>::deserialize(deserializer)?;
-            Ipv4Net::new(Ipv4Addr::new(b[0], b[1], b[2], b[3]), b[4]).map_err(serde_crate::de::Error::custom)
+            Ipv4Net::new(Ipv4Addr::new(b[0], b[1], b[2], b[3]), b[4]).map_err(serde::de::Error::custom)
         }
     }
 }

--- a/src/ipnet_serde.rs
+++ b/src/ipnet_serde.rs
@@ -1,9 +1,9 @@
 use {IpNet, Ipv4Net, Ipv6Net};
 use std::fmt;
 use std::net::{Ipv4Addr, Ipv6Addr};
-use serde::{self, Serialize, Deserialize, Serializer, Deserializer};
-use serde::ser::{SerializeTuple};
-use serde::de::{EnumAccess, Error, VariantAccess, Visitor};
+use serde_crate::{self, Serialize, Deserialize, Serializer, Deserializer};
+use serde_crate::ser::SerializeTuple;
+use serde_crate::de::{EnumAccess, Error, VariantAccess, Visitor};
 
 impl Serialize for IpNet {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -49,11 +49,12 @@ impl<'de> Deserialize<'de> for IpNet {
             struct EnumVisitor;
 
             #[derive(Serialize, Deserialize)]
+            #[serde(crate = "serde_crate")]
             enum IpNetKind {
                 V4,
                 V6,
             }
-            
+
             impl<'de> Visitor<'de> for EnumVisitor {
                 type Value = IpNet;
 
@@ -64,7 +65,7 @@ impl<'de> Deserialize<'de> for IpNet {
                 fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
                     where A: EnumAccess<'de>
                 {
-                    match try!(data.variant()) {
+                    match data.variant()? {
                         (IpNetKind::V4, v) => v.newtype_variant().map(IpNet::V4),
                         (IpNetKind::V6, v) => v.newtype_variant().map(IpNet::V6),
                     }
@@ -117,7 +118,7 @@ impl<'de> Deserialize<'de> for Ipv4Net {
             deserializer.deserialize_str(IpAddrVisitor)
         } else {
             let b = <[u8; 5]>::deserialize(deserializer)?;
-            Ipv4Net::new(Ipv4Addr::new(b[0], b[1], b[2], b[3]), b[4]).map_err(serde::de::Error::custom)
+            Ipv4Net::new(Ipv4Addr::new(b[0], b[1], b[2], b[3]), b[4]).map_err(serde_crate::de::Error::custom)
         }
     }
 }
@@ -196,7 +197,7 @@ mod tests {
             Token::TupleEnd,
         ]);
     }
-    
+
     #[test]
     fn test_serialize_ipnet_v6() {
         let net_str = "fd00::/32";
@@ -225,7 +226,7 @@ mod tests {
             Token::U8(0),
             Token::U8(32),
             Token::TupleEnd,
-        ]); 
+        ]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //! [feature]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 
 #[cfg(feature = "serde")]
-extern crate serde_crate;
+extern crate serde;
 
 pub use self::ipext::{IpAdd, IpSub, IpBitAnd, IpBitOr, IpAddrRange, Ipv4AddrRange, Ipv6AddrRange};
 pub use self::ipnet::{IpNet, Ipv4Net, Ipv6Net, PrefixLenError, IpSubnets, Ipv4Subnets, Ipv6Subnets};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,7 @@
 //! [feature]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 
 #[cfg(feature = "serde")]
-#[macro_use]
-extern crate serde;
+extern crate serde_crate;
 
 pub use self::ipext::{IpAdd, IpSub, IpBitAnd, IpBitOr, IpAddrRange, Ipv4AddrRange, Ipv6AddrRange};
 pub use self::ipnet::{IpNet, Ipv4Net, Ipv6Net, PrefixLenError, IpSubnets, Ipv4Subnets, Ipv6Subnets};


### PR DESCRIPTION
# Context

[schemars](https://docs.rs/schemars/0.8.3/schemars/index.html) is a library which allows emission of JSON schema documents based purely on a type. It's a lot like serde (and has compatibility with serde) but allows emission of JSON schemas without a "value" - it operates purely based on type.

This is super handy for things that consume JSON schemas to define types - at Oxide (my employer), we use schemars to produce OpenAPI specs for our interfaces (and consequently, types that appear in our APIs derive `Serialize`, `Deserialize`, and `JsonSchema`).

Similar to the serde types, `derive(JsonSchema)` only works if all the contained types also implement `JsonSchema`.

# Okay, what about this PR tho

This PR adds a new "feature" to ipnet, enabling the derivation of the `JsonSchema` type for `IpNet` types.
Similar to the existing `serde` feature, a new `json` feature provides a variant of this crate with the derives enabled.

For callers who want to use it: This enables usage of the `IpNet` types within other `JsonSchema` objects.
For callers who don't want it: It's behind a feature flag, so it remains completely unnoticeable (and has no impact on the compiled library).