### PR TITLE
Fix doc link

### DIFF
--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -56,7 +56,7 @@ pub enum IpNet {
 /// addresses represented in CIDR notation. See [IETF RFC 4632] for the
 /// CIDR notation.
 ///
-/// [`IpNet`]: enum.IpAddr.html
+/// [`IpNet`]: enum.IpNet.html
 /// [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html
 /// [IETF RFC 4632]: https://tools.ietf.org/html/rfc4632
 ///
@@ -86,7 +86,7 @@ pub struct Ipv4Net {
 /// addresses represented in CIDR notation. See [IETF RFC 4632] for the
 /// CIDR notation.
 ///
-/// [`IpNet`]: enum.IpAddr.html
+/// [`IpNet`]: enum.IpNet.html
 /// [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html
 /// [IETF RFC 4632]: https://tools.ietf.org/html/rfc4632
 ///


### PR DESCRIPTION
Hi!

There was a link error in the docs, this fixes it. In the [Ipv4Net](https://docs.rs/ipnet/latest/ipnet/struct.Ipv4Net.html) and [Ipv6Net](https://docs.rs/ipnet/latest/ipnet/struct.Ipv6Net.html) docs the link to [IpNet](https://docs.rs/ipnet/latest/ipnet/enum.IpNet.html) was broken and instead lead to the non-existing [IpAddr enum](https://docs.rs/ipnet/latest/ipnet/enum.IpAddr.html).