### PR TITLE
add convenience `IpNet::new` method

### DIFF
--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -120,6 +120,28 @@ impl fmt::Display for PrefixLenError {
 impl Error for PrefixLenError {}
 
 impl IpNet {
+    /// Creates a new IP network address from an `IpAddr` and prefix
+    /// length.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::Ipv6Addr;
+    /// use ipnet::{IpNet, PrefixLenError};
+    ///
+    /// let net = IpNet::new(Ipv6Addr::LOCALHOST.into(), 48);
+    /// assert!(net.is_ok());
+    /// 
+    /// let bad_prefix_len = IpNet::new(Ipv6Addr::LOCALHOST.into(), 129);
+    /// assert_eq!(bad_prefix_len, Err(PrefixLenError));
+    /// ```
+    pub fn new(ip: IpAddr, prefix_len: u8) -> Result<IpNet, PrefixLenError> {
+        Ok(match ip {
+            IpAddr::V4(a) => Ipv4Net::new(a, prefix_len)?.into(),
+            IpAddr::V6(a) => Ipv6Net::new(a, prefix_len)?.into(),
+        })
+    }
+
     /// Returns a copy of the network with the address truncated to the
     /// prefix length.
     ///


### PR DESCRIPTION
This is a convenience to avoid having extra `match` statements in the code of consumers of this crate that, like in my case, are receiving an `IpAddr` and prefix and would like to build a network out of that information.

Since the `FromStr` implementation is essentially the same situation and validation of prefix length is still handled appropriately, it would make sense for this method to exist in my opinion.