### PR TITLE
Use `Serializer::collect_str` to serialize output of Display

### DIFF
--- a/src/ipnet_serde.rs
+++ b/src/ipnet_serde.rs
@@ -81,7 +81,7 @@ impl Serialize for Ipv4Net {
         where S: Serializer
     {
         if serializer.is_human_readable() {
-            serializer.serialize_str(&self.to_string())
+            serializer.collect_str(self)
         } else {
             let mut seq = serializer.serialize_tuple(5)?;
             for octet in &self.addr().octets() {
@@ -127,7 +127,7 @@ impl Serialize for Ipv6Net {
         where S: Serializer
     {
         if serializer.is_human_readable() {
-            serializer.serialize_str(&self.to_string())
+            serializer.collect_str(self)
         } else {
             let mut seq = serializer.serialize_tuple(17)?;
             for octet in &self.addr().octets() {


### PR DESCRIPTION
[`Serializer::collect_str`](https://docs.rs/serde/1.0.136/serde/trait.Serializer.html#method.collect_str) is exactly the same as doing `Serializer::serialize_str(&thing_to_serialize.to_string())`, but some `Serializer` implementations, for example the [serde_json `Serializer`](https://docs.rs/serde_json/1.0.79/src/serde_json/ser.rs.html#447-499), avoid the allocation made by `ToString` and serialize the item in place