### PR TITLE
Allow to invoke some functions as const fn

### DIFF
--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -558,7 +558,7 @@ impl Ipv4Net {
     /// let bad_prefix_len = Ipv4Net::new(Ipv4Addr::new(10, 1, 1, 0), 33);
     /// assert_eq!(bad_prefix_len, Err(PrefixLenError));
     /// ```
-    pub fn new(ip: Ipv4Addr, prefix_len: u8) -> Result<Ipv4Net, PrefixLenError> {
+    pub const fn new(ip: Ipv4Addr, prefix_len: u8) -> Result<Ipv4Net, PrefixLenError> {
         if prefix_len > 32 {
             return Err(PrefixLenError);
         }
@@ -583,17 +583,17 @@ impl Ipv4Net {
     }
 
     /// Returns the address.
-    pub fn addr(&self) -> Ipv4Addr {
+    pub const fn addr(&self) -> Ipv4Addr {
         self.addr
     }
 
     /// Returns the prefix length.
-    pub fn prefix_len(&self) -> u8 {
+    pub const fn prefix_len(&self) -> u8 {
         self.prefix_len
     }
 
     /// Returns the maximum valid prefix length.
-    pub fn max_prefix_len(&self) -> u8 {
+    pub const fn max_prefix_len(&self) -> u8 {
         32
     }
     
@@ -889,7 +889,7 @@ impl Ipv6Net {
     /// let bad_prefix_len = Ipv6Net::new(Ipv6Addr::new(0xfd, 0, 0, 0, 0, 0, 0, 0), 129);
     /// assert_eq!(bad_prefix_len, Err(PrefixLenError));
     /// ```
-    pub fn new(ip: Ipv6Addr, prefix_len: u8) -> Result<Ipv6Net, PrefixLenError> {
+    pub const fn new(ip: Ipv6Addr, prefix_len: u8) -> Result<Ipv6Net, PrefixLenError> {
         if prefix_len > 128 {
             return Err(PrefixLenError);
         }
@@ -914,17 +914,17 @@ impl Ipv6Net {
     }
     
     /// Returns the address.
-    pub fn addr(&self) -> Ipv6Addr {
+    pub const fn addr(&self) -> Ipv6Addr {
         self.addr
     }
 
     /// Returns the prefix length.
-    pub fn prefix_len(&self) -> u8 {
+    pub const fn prefix_len(&self) -> u8 {
         self.prefix_len
     }
     
     /// Returns the maximum valid prefix length.
-    pub fn max_prefix_len(&self) -> u8 {
+    pub const fn max_prefix_len(&self) -> u8 {
         128
     }
 


### PR DESCRIPTION
This change enables to invoke functions marked as `const` in this change in [const context](https://doc.rust-lang.org/reference/const_eval.html).

By this change, for example, we can construct `Ipv6Net` or `Ipv4Net` as a global constant during a compile time. This is useful when we crate a giant table.