### PR TITLE
Inline constructors and field getters

### DIFF
--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -578,6 +578,7 @@ impl Ipv4Net {
     /// let bad_prefix_len = Ipv4Net::new(Ipv4Addr::new(10, 1, 1, 0), 33);
     /// assert_eq!(bad_prefix_len, Err(PrefixLenError));
     /// ```
+    #[inline(always)]
     pub const fn new(ip: Ipv4Addr, prefix_len: u8) -> Result<Ipv4Net, PrefixLenError> {
         if prefix_len > 32 {
             return Err(PrefixLenError);
@@ -622,16 +623,19 @@ impl Ipv4Net {
     }
 
     /// Returns the address.
+    #[inline(always)]
     pub const fn addr(&self) -> Ipv4Addr {
         self.addr
     }
 
     /// Returns the prefix length.
+    #[inline(always)]
     pub const fn prefix_len(&self) -> u8 {
         self.prefix_len
     }
 
     /// Returns the maximum valid prefix length.
+    #[inline(always)]
     pub const fn max_prefix_len(&self) -> u8 {
         32
     }
@@ -931,6 +935,7 @@ impl Ipv6Net {
     /// let bad_prefix_len = Ipv6Net::new(Ipv6Addr::new(0xfd, 0, 0, 0, 0, 0, 0, 0), 129);
     /// assert_eq!(bad_prefix_len, Err(PrefixLenError));
     /// ```
+    #[inline(always)]
     pub const fn new(ip: Ipv6Addr, prefix_len: u8) -> Result<Ipv6Net, PrefixLenError> {
         if prefix_len > 128 {
             return Err(PrefixLenError);
@@ -975,16 +980,19 @@ impl Ipv6Net {
     }
     
     /// Returns the address.
+    #[inline(always)]
     pub const fn addr(&self) -> Ipv6Addr {
         self.addr
     }
 
     /// Returns the prefix length.
+    #[inline(always)]
     pub const fn prefix_len(&self) -> u8 {
         self.prefix_len
     }
     
     /// Returns the maximum valid prefix length.
+    #[inline(always)]
     pub const fn max_prefix_len(&self) -> u8 {
         128
     }

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -578,7 +578,7 @@ impl Ipv4Net {
     /// let bad_prefix_len = Ipv4Net::new(Ipv4Addr::new(10, 1, 1, 0), 33);
     /// assert_eq!(bad_prefix_len, Err(PrefixLenError));
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn new(ip: Ipv4Addr, prefix_len: u8) -> Result<Ipv4Net, PrefixLenError> {
         if prefix_len > 32 {
             return Err(PrefixLenError);
@@ -623,19 +623,19 @@ impl Ipv4Net {
     }
 
     /// Returns the address.
-    #[inline(always)]
+    #[inline]
     pub const fn addr(&self) -> Ipv4Addr {
         self.addr
     }
 
     /// Returns the prefix length.
-    #[inline(always)]
+    #[inline]
     pub const fn prefix_len(&self) -> u8 {
         self.prefix_len
     }
 
     /// Returns the maximum valid prefix length.
-    #[inline(always)]
+    #[inline]
     pub const fn max_prefix_len(&self) -> u8 {
         32
     }
@@ -935,7 +935,7 @@ impl Ipv6Net {
     /// let bad_prefix_len = Ipv6Net::new(Ipv6Addr::new(0xfd, 0, 0, 0, 0, 0, 0, 0), 129);
     /// assert_eq!(bad_prefix_len, Err(PrefixLenError));
     /// ```
-    #[inline(always)]
+    #[inline]
     pub const fn new(ip: Ipv6Addr, prefix_len: u8) -> Result<Ipv6Net, PrefixLenError> {
         if prefix_len > 128 {
             return Err(PrefixLenError);
@@ -980,19 +980,19 @@ impl Ipv6Net {
     }
     
     /// Returns the address.
-    #[inline(always)]
+    #[inline]
     pub const fn addr(&self) -> Ipv6Addr {
         self.addr
     }
 
     /// Returns the prefix length.
-    #[inline(always)]
+    #[inline]
     pub const fn prefix_len(&self) -> u8 {
         self.prefix_len
     }
     
     /// Returns the maximum valid prefix length.
-    #[inline(always)]
+    #[inline]
     pub const fn max_prefix_len(&self) -> u8 {
         128
     }


### PR DESCRIPTION
Recently, I have been running into some performance issues while reading BGP table dumps. After doing a number of profiles using VTune on Windows and valgrind on Linux, I found one of performance issues is caused by a missed optimization involving `Ipv6Net::new`. There are a number of other performance issues with my program that I still need to look at, however this one is by far the easiest to fix.

The crux of the issue is that Rust uses thin LTO by default so inlining is not performed across codegen units unless explicitly requested via `#[inline]` (or when constructed for a generic type, but that isn't the case here). While it is possible to avoid this by enabling [fat LTO](https://doc.rust-lang.org/cargo/reference/profiles.html#lto) within a crate's `Cargo.toml`, this setting is ignored when compiling dependencies making this solution ineffective for library developers.

As you can see in this screenshot of a profile I ran in VTune, `Ipv6Net::new` took up a massive 10% (2.972 seconds) of the total program runtime. This large amount of CPU time is only  possible because my workload of going through BGP data consists almost entirely of reading IPv6 prefixes. However, all of the work being done by this function is unnecessary when viewed in the context of the caller. The majority of the time spent by this function is constructing the return value from the function arguments. When inlined, the compiler is able to construct the `Ipv6Net` in place so these moves are not required. Thanks to branch prediction the impact of the `prefix_len` check is minimal, but when inlined the compiler is able to reliably remove the entire check.
![image](https://user-images.githubusercontent.com/5491072/224849751-98f95848-65ee-4b2d-94d6-f40e5a6c9b96.png)

In this pull request I propose adding `#[inline(always)]` to the constructors (`Ipv6Net::new` and `Ipv4Net::new`) and getters (`Ipv6Net::addr`, `Ipv6Net::prefix_len`, `Ipv4Net::addr`, and `Ipv4Net::prefix_len`). Additionally I added `#[inline(always)]` to `Ipv6::max_prefix_len` and `Ipv4::max_prefix_len` as they were the only other `const` functions in the crate and I saw no downside in doing so.