### PR TITLE
Add `no_std` support on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ documentation = "https://docs.rs/ipnet"
 edition = "2018"
 
 [features]
-default = []
+default = ["std"]
+std = []
 # Implements "schemars::JsonSchema". Also implies "serde".
 json = ["serde", "schemars"]
 

--- a/src/ipext.rs
+++ b/src/ipext.rs
@@ -4,9 +4,12 @@
 //! the `Ipv4Addr` and `Ipv6Addr` types with methods to perform these
 //! operations.
 
-use std::cmp::Ordering::{Less, Equal};
-use std::iter::{FusedIterator, DoubleEndedIterator};
-use std::mem;
+use core::cmp::Ordering::{Equal, Less};
+use core::iter::{DoubleEndedIterator, FusedIterator};
+use core::mem;
+#[cfg(not(feature = "std"))]
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+#[cfg(feature = "std")]
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 /// Provides a `saturating_add()` method for `Ipv4Addr` and `Ipv6Addr`.
@@ -18,7 +21,11 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 /// # Examples
 ///
 /// ```
+/// # #![cfg_attr(not(feature = "std"), feature(ip_in_core))]
+/// # #[cfg(feature = "std")]
 /// use std::net::{Ipv4Addr, Ipv6Addr};
+/// # #[cfg(not(feature = "std"))]
+/// # use core::net::{Ipv4Addr, Ipv6Addr};
 /// use ipnet::IpAdd;
 ///
 /// let ip0: Ipv4Addr = "192.168.0.0".parse().unwrap();
@@ -58,7 +65,11 @@ pub trait IpAdd<RHS = Self> {
 /// # Examples
 ///
 /// ```
+/// # #![cfg_attr(not(feature = "std"), feature(ip_in_core))]
+/// # #[cfg(feature = "std")]
 /// use std::net::{Ipv4Addr, Ipv6Addr};
+/// # #[cfg(not(feature = "std"))]
+/// # use core::net::{Ipv4Addr, Ipv6Addr};
 /// use ipnet::IpSub;
 ///
 /// let min: Ipv4Addr = "0.0.0.0".parse().unwrap();
@@ -69,7 +80,7 @@ pub trait IpAdd<RHS = Self> {
 /// assert_eq!(ip2.saturating_sub(ip1), 95);
 /// assert_eq!(min.saturating_sub(5), min);
 /// assert_eq!(ip2.saturating_sub(95), ip1);
-/// 
+///
 /// let min: Ipv6Addr = "::".parse().unwrap();
 /// let ip1: Ipv6Addr = "fd00::5".parse().unwrap();
 /// let ip2: Ipv6Addr = "fd00::64".parse().unwrap();
@@ -89,7 +100,11 @@ pub trait IpSub<RHS = Self> {
 /// # Examples
 ///
 /// ```
+/// # #![cfg_attr(not(feature = "std"), feature(ip_in_core))]
+/// # #[cfg(feature = "std")]
 /// use std::net::{Ipv4Addr, Ipv6Addr};
+/// # #[cfg(not(feature = "std"))]
+/// # use core::net::{Ipv4Addr, Ipv6Addr};
 /// use ipnet::IpBitAnd;
 ///
 /// let ip: Ipv4Addr = "192.168.1.1".parse().unwrap();
@@ -98,7 +113,7 @@ pub trait IpSub<RHS = Self> {
 ///
 /// assert_eq!(ip.bitand(mask), res);
 /// assert_eq!(ip.bitand(0xffff0000), res);
-/// 
+///
 /// let ip: Ipv6Addr = "fd00:1234::1".parse().unwrap();
 /// let mask: Ipv6Addr = "ffff::".parse().unwrap();
 /// let res: Ipv6Addr = "fd00::".parse().unwrap();
@@ -116,7 +131,11 @@ pub trait IpBitAnd<RHS = Self> {
 /// # Examples
 ///
 /// ```
+/// # #![cfg_attr(not(feature = "std"), feature(ip_in_core))]
+/// # #[cfg(feature = "std")]
 /// use std::net::{Ipv4Addr, Ipv6Addr};
+/// # #[cfg(not(feature = "std"))]
+/// # use core::net::{Ipv4Addr, Ipv6Addr};
 /// use ipnet::IpBitOr;
 ///
 /// let ip: Ipv4Addr = "10.1.1.1".parse().unwrap();
@@ -125,7 +144,7 @@ pub trait IpBitAnd<RHS = Self> {
 ///
 /// assert_eq!(ip.bitor(mask), res);
 /// assert_eq!(ip.bitor(0x000000ff), res);
-/// 
+///
 /// let ip: Ipv6Addr = "fd00::1".parse().unwrap();
 /// let mask: Ipv6Addr = "::ffff:ffff".parse().unwrap();
 /// let res: Ipv6Addr = "fd00::ffff:ffff".parse().unwrap();
@@ -139,7 +158,7 @@ pub trait IpBitOr<RHS = Self> {
 }
 
 macro_rules! ip_add_impl {
-    ($lhs:ty, $rhs:ty, $output:ty, $inner:ty) => (
+    ($lhs:ty, $rhs:ty, $output:ty, $inner:ty) => {
         impl IpAdd<$rhs> for $lhs {
             type Output = $output;
 
@@ -149,11 +168,11 @@ macro_rules! ip_add_impl {
                 (lhs.saturating_add(rhs.into())).into()
             }
         }
-    )
+    };
 }
 
 macro_rules! ip_sub_impl {
-    ($lhs:ty, $rhs:ty, $output:ty, $inner:ty) => (
+    ($lhs:ty, $rhs:ty, $output:ty, $inner:ty) => {
         impl IpSub<$rhs> for $lhs {
             type Output = $output;
 
@@ -163,7 +182,7 @@ macro_rules! ip_sub_impl {
                 (lhs.saturating_sub(rhs.into())).into()
             }
         }
-    )
+    };
 }
 
 ip_add_impl!(Ipv4Addr, u32, Ipv4Addr, u32);
@@ -252,7 +271,11 @@ impl IpStep for Ipv6Addr {
 /// # Examples
 ///
 /// ```
+/// # #![cfg_attr(not(feature = "std"), feature(ip_in_core))]
+/// # #[cfg(feature = "std")]
 /// use std::net::IpAddr;
+/// # #[cfg(not(feature = "std"))]
+/// # use core::net::IpAddr;
 /// use ipnet::{IpAddrRange, Ipv4AddrRange, Ipv6AddrRange};
 ///
 /// let hosts = IpAddrRange::from(Ipv4AddrRange::new(
@@ -290,7 +313,11 @@ pub enum IpAddrRange {
 /// # Examples
 ///
 /// ```
+/// # #![cfg_attr(not(feature = "std"), feature(ip_in_core))]
+/// # #[cfg(feature = "std")]
 /// use std::net::Ipv4Addr;
+/// # #[cfg(not(feature = "std"))]
+/// # use core::net::Ipv4Addr;
 /// use ipnet::Ipv4AddrRange;
 ///
 /// let hosts = Ipv4AddrRange::new(
@@ -316,7 +343,11 @@ pub struct Ipv4AddrRange {
 /// # Examples
 ///
 /// ```
+/// # #![cfg_attr(not(feature = "std"), feature(ip_in_core))]
+/// # #[cfg(feature = "std")]
 /// use std::net::Ipv6Addr;
+/// # #[cfg(not(feature = "std"))]
+/// # use core::net::Ipv6Addr;
 /// use ipnet::Ipv6AddrRange;
 ///
 /// let hosts = Ipv6AddrRange::new(
@@ -364,7 +395,7 @@ impl Ipv4AddrRange {
                 let count: u32 = self.end.saturating_sub(self.start);
                 let count = count as u64 + 1; // Never overflows
                 count
-            },
+            }
             Some(Equal) => 1,
             _ => 0,
         }
@@ -387,7 +418,7 @@ impl Ipv6AddrRange {
                 let count = self.end.saturating_sub(self.start);
                 // May overflow or panic
                 count + 1
-            },
+            }
             Some(Equal) => 1,
             _ => 0,
         }
@@ -395,7 +426,10 @@ impl Ipv6AddrRange {
     /// True only if count_u128 does not overflow
     fn can_count_u128(&self) -> bool {
         self.start != Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)
-        || self.end != Ipv6Addr::new(0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
+            || self.end
+                != Ipv6Addr::new(
+                    0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
+                )
     }
 }
 
@@ -460,11 +494,11 @@ impl Iterator for Ipv4AddrRange {
             Some(Less) => {
                 let next = self.start.add_one();
                 Some(mem::replace(&mut self.start, next))
-            },
+            }
             Some(Equal) => {
                 self.end.replace_zero();
                 Some(self.start.replace_one())
-            },
+            }
             _ => None,
         }
     }
@@ -481,16 +515,16 @@ impl Iterator for Ipv4AddrRange {
                 // so need to explicitly check for overflow.
                 // 'usize::MAX as u32' is okay here - if usize is 64 bits,
                 // value truncates to u32::MAX
-                if count <= std::usize::MAX as u32 {
+                if count <= core::usize::MAX as u32 {
                     count as usize + 1
                 // count overflows usize
                 } else {
                     // emulate standard overflow/panic behavior
-                    std::usize::MAX + 2 + count as usize
+                    core::usize::MAX + 2 + count as usize
                 }
-            },
+            }
             Some(Equal) => 1,
-            _ => 0
+            _ => 0,
         }
     }
 
@@ -508,7 +542,7 @@ impl Iterator for Ipv4AddrRange {
     fn min(self) -> Option<Self::Item> {
         match self.start.partial_cmp(&self.end) {
             Some(Less) | Some(Equal) => Some(self.start),
-            _ => None
+            _ => None,
         }
     }
 
@@ -531,8 +565,8 @@ impl Iterator for Ipv4AddrRange {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let count = self.count_u64();
-        if count > std::usize::MAX as u64 {
-            (std::usize::MAX, None)
+        if count > core::usize::MAX as u64 {
+            (core::usize::MAX, None)
         } else {
             let count = count as usize;
             (count, Some(count))
@@ -548,11 +582,11 @@ impl Iterator for Ipv6AddrRange {
             Some(Less) => {
                 let next = self.start.add_one();
                 Some(mem::replace(&mut self.start, next))
-            },
+            }
             Some(Equal) => {
                 self.end.replace_zero();
                 Some(self.start.replace_one())
-            },
+            }
             _ => None,
         }
     }
@@ -561,12 +595,12 @@ impl Iterator for Ipv6AddrRange {
     fn count(self) -> usize {
         let count = self.count_u128();
         // count fits in usize
-        if count <= std::usize::MAX as u128 {
+        if count <= core::usize::MAX as u128 {
             count as usize
         // count does not fit in usize
         } else {
             // emulate standard overflow/panic behavior
-            std::usize::MAX + 1 + count as usize
+            core::usize::MAX + 1 + count as usize
         }
     }
 
@@ -584,7 +618,7 @@ impl Iterator for Ipv6AddrRange {
     fn min(self) -> Option<Self::Item> {
         match self.start.partial_cmp(&self.end) {
             Some(Less) | Some(Equal) => Some(self.start),
-            _ => None
+            _ => None,
         }
     }
 
@@ -616,14 +650,14 @@ impl Iterator for Ipv6AddrRange {
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.can_count_u128() {
             let count = self.count_u128();
-            if count > std::usize::MAX as u128 {
-                (std::usize::MAX, None)
+            if count > core::usize::MAX as u128 {
+                (core::usize::MAX, None)
             } else {
                 let count = count as usize;
                 (count, Some(count))
             }
         } else {
-            (std::usize::MAX, None)
+            (core::usize::MAX, None)
         }
     }
 }
@@ -649,12 +683,12 @@ impl DoubleEndedIterator for Ipv4AddrRange {
             Some(Less) => {
                 let next_back = self.end.sub_one();
                 Some(mem::replace(&mut self.end, next_back))
-            },
+            }
             Some(Equal) => {
                 self.end.replace_zero();
                 Some(self.start.replace_one())
-            },
-            _ => None
+            }
+            _ => None,
         }
     }
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
@@ -681,12 +715,12 @@ impl DoubleEndedIterator for Ipv6AddrRange {
             Some(Less) => {
                 let next_back = self.end.sub_one();
                 Some(mem::replace(&mut self.end, next_back))
-            },
+            }
             Some(Equal) => {
                 self.end.replace_zero();
                 Some(self.start.replace_one())
-            },
-            _ => None
+            }
+            _ => None,
         }
     }
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
@@ -697,8 +731,7 @@ impl DoubleEndedIterator for Ipv6AddrRange {
                 self.end.replace_zero();
                 self.start.replace_one();
                 None
-            }
-            else if n == count - 1 {
+            } else if n == count - 1 {
                 self.end.replace_zero();
                 Some(self.start.replace_one())
             } else {
@@ -722,24 +755,30 @@ impl FusedIterator for Ipv6AddrRange {}
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-    use std::str::FromStr;
     use super::*;
+    #[cfg(feature = "std")]
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    #[cfg(not(feature = "std"))]
+    use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use alloc::{str::FromStr, vec::Vec};
 
     #[test]
     fn test_ipaddrrange() {
         // Next, Next-Back
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap()
+            Ipv4Addr::from_str("10.0.0.3").unwrap(),
         );
 
-        assert_eq!(i.collect::<Vec<Ipv4Addr>>(), vec![
-            Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.1").unwrap(),
-            Ipv4Addr::from_str("10.0.0.2").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<Ipv4Addr>>(),
+            vec![
+                Ipv4Addr::from_str("10.0.0.0").unwrap(),
+                Ipv4Addr::from_str("10.0.0.1").unwrap(),
+                Ipv4Addr::from_str("10.0.0.2").unwrap(),
+                Ipv4Addr::from_str("10.0.0.3").unwrap(),
+            ]
+        );
 
         let mut v = i.collect::<Vec<_>>();
         v.reverse();
@@ -747,25 +786,31 @@ mod tests {
 
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("255.255.255.254").unwrap(),
-            Ipv4Addr::from_str("255.255.255.255").unwrap()
+            Ipv4Addr::from_str("255.255.255.255").unwrap(),
         );
 
-        assert_eq!(i.collect::<Vec<Ipv4Addr>>(), vec![
-            Ipv4Addr::from_str("255.255.255.254").unwrap(),
-            Ipv4Addr::from_str("255.255.255.255").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<Ipv4Addr>>(),
+            vec![
+                Ipv4Addr::from_str("255.255.255.254").unwrap(),
+                Ipv4Addr::from_str("255.255.255.255").unwrap(),
+            ]
+        );
 
         let i = Ipv6AddrRange::new(
             Ipv6Addr::from_str("fd00::").unwrap(),
             Ipv6Addr::from_str("fd00::3").unwrap(),
         );
 
-        assert_eq!(i.collect::<Vec<Ipv6Addr>>(), vec![
-            Ipv6Addr::from_str("fd00::").unwrap(),
-            Ipv6Addr::from_str("fd00::1").unwrap(),
-            Ipv6Addr::from_str("fd00::2").unwrap(),
-            Ipv6Addr::from_str("fd00::3").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<Ipv6Addr>>(),
+            vec![
+                Ipv6Addr::from_str("fd00::").unwrap(),
+                Ipv6Addr::from_str("fd00::1").unwrap(),
+                Ipv6Addr::from_str("fd00::2").unwrap(),
+                Ipv6Addr::from_str("fd00::3").unwrap(),
+            ]
+        );
 
         let mut v = i.collect::<Vec<_>>();
         v.reverse();
@@ -776,48 +821,60 @@ mod tests {
             Ipv6Addr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
         );
 
-        assert_eq!(i.collect::<Vec<Ipv6Addr>>(), vec![
-            Ipv6Addr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe").unwrap(),
-            Ipv6Addr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
-        ]);
-        
+        assert_eq!(
+            i.collect::<Vec<Ipv6Addr>>(),
+            vec![
+                Ipv6Addr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe").unwrap(),
+                Ipv6Addr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
+            ]
+        );
+
         let i = IpAddrRange::from(Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
             Ipv4Addr::from_str("10.0.0.3").unwrap(),
         ));
 
-        assert_eq!(i.collect::<Vec<IpAddr>>(), vec![
-            IpAddr::from_str("10.0.0.0").unwrap(),
-            IpAddr::from_str("10.0.0.1").unwrap(),
-            IpAddr::from_str("10.0.0.2").unwrap(),
-            IpAddr::from_str("10.0.0.3").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<IpAddr>>(),
+            vec![
+                IpAddr::from_str("10.0.0.0").unwrap(),
+                IpAddr::from_str("10.0.0.1").unwrap(),
+                IpAddr::from_str("10.0.0.2").unwrap(),
+                IpAddr::from_str("10.0.0.3").unwrap(),
+            ]
+        );
 
         let mut v = i.collect::<Vec<_>>();
         v.reverse();
         assert_eq!(v, i.rev().collect::<Vec<_>>());
-        
+
         let i = IpAddrRange::from(Ipv4AddrRange::new(
             Ipv4Addr::from_str("255.255.255.254").unwrap(),
-            Ipv4Addr::from_str("255.255.255.255").unwrap()
+            Ipv4Addr::from_str("255.255.255.255").unwrap(),
         ));
 
-        assert_eq!(i.collect::<Vec<IpAddr>>(), vec![
-            IpAddr::from_str("255.255.255.254").unwrap(),
-            IpAddr::from_str("255.255.255.255").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<IpAddr>>(),
+            vec![
+                IpAddr::from_str("255.255.255.254").unwrap(),
+                IpAddr::from_str("255.255.255.255").unwrap(),
+            ]
+        );
 
         let i = IpAddrRange::from(Ipv6AddrRange::new(
             Ipv6Addr::from_str("fd00::").unwrap(),
             Ipv6Addr::from_str("fd00::3").unwrap(),
         ));
 
-        assert_eq!(i.collect::<Vec<IpAddr>>(), vec![
-            IpAddr::from_str("fd00::").unwrap(),
-            IpAddr::from_str("fd00::1").unwrap(),
-            IpAddr::from_str("fd00::2").unwrap(),
-            IpAddr::from_str("fd00::3").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<IpAddr>>(),
+            vec![
+                IpAddr::from_str("fd00::").unwrap(),
+                IpAddr::from_str("fd00::1").unwrap(),
+                IpAddr::from_str("fd00::2").unwrap(),
+                IpAddr::from_str("fd00::3").unwrap(),
+            ]
+        );
 
         let mut v = i.collect::<Vec<_>>();
         v.reverse();
@@ -828,10 +885,13 @@ mod tests {
             Ipv6Addr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
         ));
 
-        assert_eq!(i.collect::<Vec<IpAddr>>(), vec![
-            IpAddr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe").unwrap(),
-            IpAddr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<IpAddr>>(),
+            vec![
+                IpAddr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe").unwrap(),
+                IpAddr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
+            ]
+        );
 
         // #11 (infinite iterator when start and stop are 0)
         let zero4 = Ipv4Addr::from_str("0.0.0.0").unwrap();
@@ -848,7 +908,7 @@ mod tests {
         // Count
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap()
+            Ipv4Addr::from_str("10.0.0.3").unwrap(),
         );
         assert_eq!(i.count(), 4);
 
@@ -861,7 +921,7 @@ mod tests {
         // Size Hint
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap()
+            Ipv4Addr::from_str("10.0.0.3").unwrap(),
         );
         assert_eq!(i.size_hint(), (4, Some(4)));
 
@@ -876,32 +936,50 @@ mod tests {
             Ipv6Addr::from_str("::").unwrap(),
             Ipv6Addr::from_str("8000::").unwrap(),
         );
-        assert_eq!(i.size_hint(), (std::usize::MAX, None));
+        assert_eq!(i.size_hint(), (core::usize::MAX, None));
 
         // Min, Max, Last
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap()
+            Ipv4Addr::from_str("10.0.0.3").unwrap(),
         );
-        assert_eq!(Iterator::min(i), Some(Ipv4Addr::from_str("10.0.0.0").unwrap()));
-        assert_eq!(Iterator::max(i), Some(Ipv4Addr::from_str("10.0.0.3").unwrap()));
+        assert_eq!(
+            Iterator::min(i),
+            Some(Ipv4Addr::from_str("10.0.0.0").unwrap())
+        );
+        assert_eq!(
+            Iterator::max(i),
+            Some(Ipv4Addr::from_str("10.0.0.3").unwrap())
+        );
         assert_eq!(i.last(), Some(Ipv4Addr::from_str("10.0.0.3").unwrap()));
 
         let i = Ipv6AddrRange::new(
             Ipv6Addr::from_str("fd00::").unwrap(),
             Ipv6Addr::from_str("fd00::3").unwrap(),
         );
-        assert_eq!(Iterator::min(i), Some(Ipv6Addr::from_str("fd00::").unwrap()));
-        assert_eq!(Iterator::max(i), Some(Ipv6Addr::from_str("fd00::3").unwrap()));
+        assert_eq!(
+            Iterator::min(i),
+            Some(Ipv6Addr::from_str("fd00::").unwrap())
+        );
+        assert_eq!(
+            Iterator::max(i),
+            Some(Ipv6Addr::from_str("fd00::3").unwrap())
+        );
         assert_eq!(i.last(), Some(Ipv6Addr::from_str("fd00::3").unwrap()));
 
         // Nth
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap()
+            Ipv4Addr::from_str("10.0.0.3").unwrap(),
         );
-        assert_eq!(i.clone().nth(0), Some(Ipv4Addr::from_str("10.0.0.0").unwrap()));
-        assert_eq!(i.clone().nth(3), Some(Ipv4Addr::from_str("10.0.0.3").unwrap()));
+        assert_eq!(
+            i.clone().nth(0),
+            Some(Ipv4Addr::from_str("10.0.0.0").unwrap())
+        );
+        assert_eq!(
+            i.clone().nth(3),
+            Some(Ipv4Addr::from_str("10.0.0.3").unwrap())
+        );
         assert_eq!(i.clone().nth(4), None);
         assert_eq!(i.clone().nth(99), None);
         let mut i2 = i.clone();
@@ -916,8 +994,14 @@ mod tests {
             Ipv6Addr::from_str("fd00::").unwrap(),
             Ipv6Addr::from_str("fd00::3").unwrap(),
         );
-        assert_eq!(i.clone().nth(0), Some(Ipv6Addr::from_str("fd00::").unwrap()));
-        assert_eq!(i.clone().nth(3), Some(Ipv6Addr::from_str("fd00::3").unwrap()));
+        assert_eq!(
+            i.clone().nth(0),
+            Some(Ipv6Addr::from_str("fd00::").unwrap())
+        );
+        assert_eq!(
+            i.clone().nth(3),
+            Some(Ipv6Addr::from_str("fd00::3").unwrap())
+        );
         assert_eq!(i.clone().nth(4), None);
         assert_eq!(i.clone().nth(99), None);
         let mut i2 = i.clone();
@@ -931,15 +1015,27 @@ mod tests {
         // Nth Back
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap()
+            Ipv4Addr::from_str("10.0.0.3").unwrap(),
         );
-        assert_eq!(i.clone().nth_back(0), Some(Ipv4Addr::from_str("10.0.0.3").unwrap()));
-        assert_eq!(i.clone().nth_back(3), Some(Ipv4Addr::from_str("10.0.0.0").unwrap()));
+        assert_eq!(
+            i.clone().nth_back(0),
+            Some(Ipv4Addr::from_str("10.0.0.3").unwrap())
+        );
+        assert_eq!(
+            i.clone().nth_back(3),
+            Some(Ipv4Addr::from_str("10.0.0.0").unwrap())
+        );
         assert_eq!(i.clone().nth_back(4), None);
         assert_eq!(i.clone().nth_back(99), None);
         let mut i2 = i.clone();
-        assert_eq!(i2.nth_back(1), Some(Ipv4Addr::from_str("10.0.0.2").unwrap()));
-        assert_eq!(i2.nth_back(1), Some(Ipv4Addr::from_str("10.0.0.0").unwrap()));
+        assert_eq!(
+            i2.nth_back(1),
+            Some(Ipv4Addr::from_str("10.0.0.2").unwrap())
+        );
+        assert_eq!(
+            i2.nth_back(1),
+            Some(Ipv4Addr::from_str("10.0.0.0").unwrap())
+        );
         assert_eq!(i2.nth_back(0), None);
         let mut i3 = i.clone();
         assert_eq!(i3.nth_back(99), None);
@@ -949,8 +1045,14 @@ mod tests {
             Ipv6Addr::from_str("fd00::").unwrap(),
             Ipv6Addr::from_str("fd00::3").unwrap(),
         );
-        assert_eq!(i.clone().nth_back(0), Some(Ipv6Addr::from_str("fd00::3").unwrap()));
-        assert_eq!(i.clone().nth_back(3), Some(Ipv6Addr::from_str("fd00::").unwrap()));
+        assert_eq!(
+            i.clone().nth_back(0),
+            Some(Ipv6Addr::from_str("fd00::3").unwrap())
+        );
+        assert_eq!(
+            i.clone().nth_back(3),
+            Some(Ipv6Addr::from_str("fd00::").unwrap())
+        );
         assert_eq!(i.clone().nth_back(4), None);
         assert_eq!(i.clone().nth_back(99), None);
         let mut i2 = i.clone();

--- a/src/ipnet_schemars.rs
+++ b/src/ipnet_schemars.rs
@@ -1,8 +1,15 @@
+use crate::IpNet;
 use crate::Ipv4Net;
 use crate::Ipv6Net;
-use crate::IpNet;
 
-use schemars::{JsonSchema, gen::SchemaGenerator, schema::{SubschemaValidation, Schema, SchemaObject, StringValidation, Metadata, SingleOrVec, InstanceType}};
+use schemars::{
+    gen::SchemaGenerator,
+    schema::{
+        InstanceType, Metadata, Schema, SchemaObject, SingleOrVec, StringValidation,
+        SubschemaValidation,
+    },
+    JsonSchema,
+};
 
 impl JsonSchema for Ipv4Net {
     fn schema_name() -> String {
@@ -28,7 +35,7 @@ impl JsonSchema for Ipv4Net {
                 ..Default::default()
             })),
             ..Default::default()
-        }) 
+        })
     }
 }
 impl JsonSchema for Ipv6Net {
@@ -51,11 +58,13 @@ impl JsonSchema for Ipv6Net {
             string: Some(Box::new(StringValidation {
                 max_length: Some(43),
                 min_length: None,
-                pattern: Some(r#"^[0-9A-Fa-f:\.]+\/(?:[0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$"#.to_string()),
+                pattern: Some(
+                    r#"^[0-9A-Fa-f:\.]+\/(?:[0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$"#.to_string(),
+                ),
                 ..Default::default()
             })),
             ..Default::default()
-        }) 
+        })
     }
 }
 impl JsonSchema for IpNet {
@@ -74,13 +83,11 @@ impl JsonSchema for IpNet {
                 ],
                 ..Default::default()
             })),
-            subschemas: Some(Box::new(
-                SubschemaValidation {
-                    one_of: Some(vec![Ipv4Net::json_schema(gen), Ipv6Net::json_schema(gen)]),
-                    ..Default::default()
-                }
-            )),
+            subschemas: Some(Box::new(SubschemaValidation {
+                one_of: Some(vec![Ipv4Net::json_schema(gen), Ipv6Net::json_schema(gen)]),
+                ..Default::default()
+            })),
             ..Default::default()
-        }) 
+        })
     }
 }

--- a/src/ipnet_serde.rs
+++ b/src/ipnet_serde.rs
@@ -1,13 +1,17 @@
 use crate::{IpNet, Ipv4Net, Ipv6Net};
-use std::fmt;
-use std::net::{Ipv4Addr, Ipv6Addr};
-use serde::{self, Serialize, Deserialize, Serializer, Deserializer};
-use serde::ser::SerializeTuple;
+use core::fmt;
+#[cfg(not(feature = "std"))]
+use core::net::{Ipv4Addr, Ipv6Addr};
 use serde::de::{EnumAccess, Error, VariantAccess, Visitor};
+use serde::ser::SerializeTuple;
+use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+#[cfg(feature = "std")]
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 impl Serialize for IpNet {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         if serializer.is_human_readable() {
             match *self {
@@ -25,7 +29,8 @@ impl Serialize for IpNet {
 
 impl<'de> Deserialize<'de> for IpNet {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         if deserializer.is_human_readable() {
             struct IpNetVisitor;
@@ -38,7 +43,8 @@ impl<'de> Deserialize<'de> for IpNet {
                 }
 
                 fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-                    where E: Error
+                where
+                    E: Error,
                 {
                     s.parse().map_err(Error::custom)
                 }
@@ -62,7 +68,8 @@ impl<'de> Deserialize<'de> for IpNet {
                 }
 
                 fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
-                    where A: EnumAccess<'de>
+                where
+                    A: EnumAccess<'de>,
                 {
                     match data.variant()? {
                         (IpNetKind::V4, v) => v.newtype_variant().map(IpNet::V4),
@@ -78,7 +85,8 @@ impl<'de> Deserialize<'de> for IpNet {
 
 impl Serialize for Ipv4Net {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         if serializer.is_human_readable() {
             serializer.collect_str(self)
@@ -95,7 +103,8 @@ impl Serialize for Ipv4Net {
 
 impl<'de> Deserialize<'de> for Ipv4Net {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         if deserializer.is_human_readable() {
             struct IpAddrVisitor;
@@ -108,7 +117,8 @@ impl<'de> Deserialize<'de> for Ipv4Net {
                 }
 
                 fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-                    where E: Error
+                where
+                    E: Error,
                 {
                     s.parse().map_err(Error::custom)
                 }
@@ -117,14 +127,16 @@ impl<'de> Deserialize<'de> for Ipv4Net {
             deserializer.deserialize_str(IpAddrVisitor)
         } else {
             let b = <[u8; 5]>::deserialize(deserializer)?;
-            Ipv4Net::new(Ipv4Addr::new(b[0], b[1], b[2], b[3]), b[4]).map_err(serde::de::Error::custom)
+            Ipv4Net::new(Ipv4Addr::new(b[0], b[1], b[2], b[3]), b[4])
+                .map_err(serde::de::Error::custom)
         }
     }
 }
 
 impl Serialize for Ipv6Net {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         if serializer.is_human_readable() {
             serializer.collect_str(self)
@@ -141,7 +153,8 @@ impl Serialize for Ipv6Net {
 
 impl<'de> Deserialize<'de> for Ipv6Net {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         if deserializer.is_human_readable() {
             struct IpAddrVisitor;
@@ -154,7 +167,8 @@ impl<'de> Deserialize<'de> for Ipv6Net {
                 }
 
                 fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-                    where E: Error
+                where
+                    E: Error,
                 {
                     s.parse().map_err(Error::custom)
                 }
@@ -163,12 +177,20 @@ impl<'de> Deserialize<'de> for Ipv6Net {
             deserializer.deserialize_str(IpAddrVisitor)
         } else {
             let b = <[u8; 17]>::deserialize(deserializer)?;
-            Ipv6Net::new(Ipv6Addr::new(
-                ((b[0] as u16) << 8) | b[1] as u16, ((b[2] as u16) << 8) | b[3] as u16,
-                ((b[4] as u16) << 8) | b[5] as u16, ((b[6] as u16) << 8) | b[7] as u16,
-                ((b[8] as u16) << 8) | b[9] as u16, ((b[10] as u16) << 8) | b[11] as u16,
-                ((b[12] as u16) << 8) | b[13] as u16, ((b[14] as u16) << 8) | b[15] as u16
-            ), b[16]).map_err(Error::custom)
+            Ipv6Net::new(
+                Ipv6Addr::new(
+                    ((b[0] as u16) << 8) | b[1] as u16,
+                    ((b[2] as u16) << 8) | b[3] as u16,
+                    ((b[4] as u16) << 8) | b[5] as u16,
+                    ((b[6] as u16) << 8) | b[7] as u16,
+                    ((b[8] as u16) << 8) | b[9] as u16,
+                    ((b[10] as u16) << 8) | b[11] as u16,
+                    ((b[12] as u16) << 8) | b[13] as u16,
+                    ((b[14] as u16) << 8) | b[15] as u16,
+                ),
+                b[16],
+            )
+            .map_err(Error::custom)
         }
     }
 }
@@ -177,24 +199,30 @@ impl<'de> Deserialize<'de> for Ipv6Net {
 mod tests {
     extern crate serde_test;
 
-    use crate::{IpNet, Ipv4Net, Ipv6Net};
     use self::serde_test::{assert_tokens, Configure, Token};
+    use crate::{IpNet, Ipv4Net, Ipv6Net};
 
     #[test]
     fn test_serialize_ipnet_v4() {
         let net_str = "10.1.1.0/24";
         let net: IpNet = net_str.parse().unwrap();
         assert_tokens(&net.readable(), &[Token::Str(net_str)]);
-        assert_tokens(&net.compact(), &[
-            Token::NewtypeVariant { name: "IpNet", variant: "V4", },
-            Token::Tuple { len: 5 },
-            Token::U8(10),
-            Token::U8(1),
-            Token::U8(1),
-            Token::U8(0),
-            Token::U8(24),
-            Token::TupleEnd,
-        ]);
+        assert_tokens(
+            &net.compact(),
+            &[
+                Token::NewtypeVariant {
+                    name: "IpNet",
+                    variant: "V4",
+                },
+                Token::Tuple { len: 5 },
+                Token::U8(10),
+                Token::U8(1),
+                Token::U8(1),
+                Token::U8(0),
+                Token::U8(24),
+                Token::TupleEnd,
+            ],
+        );
     }
 
     #[test]
@@ -202,30 +230,36 @@ mod tests {
         let net_str = "fd00::/32";
         let net: IpNet = net_str.parse().unwrap();
         assert_tokens(&net.readable(), &[Token::Str(net_str)]);
-        assert_tokens(&net.compact(), &[
-            Token::NewtypeVariant { name: "IpNet", variant: "V6", },
-            // This is too painful, but Token::Bytes() seems to be
-            // an array with a length, which is not what we serialize.
-            Token::Tuple { len: 17 },
-            Token::U8(253u8),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(32),
-            Token::TupleEnd,
-        ]);
+        assert_tokens(
+            &net.compact(),
+            &[
+                Token::NewtypeVariant {
+                    name: "IpNet",
+                    variant: "V6",
+                },
+                // This is too painful, but Token::Bytes() seems to be
+                // an array with a length, which is not what we serialize.
+                Token::Tuple { len: 17 },
+                Token::U8(253u8),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(32),
+                Token::TupleEnd,
+            ],
+        );
     }
 
     #[test]
@@ -233,15 +267,18 @@ mod tests {
         let net_str = "10.1.1.0/24";
         let net: Ipv4Net = net_str.parse().unwrap();
         assert_tokens(&net.readable(), &[Token::Str(net_str)]);
-        assert_tokens(&net.compact(), &[
-            Token::Tuple { len: 5 },
-            Token::U8(10),
-            Token::U8(1),
-            Token::U8(1),
-            Token::U8(0),
-            Token::U8(24),
-            Token::TupleEnd,
-        ]);
+        assert_tokens(
+            &net.compact(),
+            &[
+                Token::Tuple { len: 5 },
+                Token::U8(10),
+                Token::U8(1),
+                Token::U8(1),
+                Token::U8(0),
+                Token::U8(24),
+                Token::TupleEnd,
+            ],
+        );
     }
 
     #[test]
@@ -249,28 +286,31 @@ mod tests {
         let net_str = "fd00::/32";
         let net: Ipv6Net = net_str.parse().unwrap();
         assert_tokens(&net.readable(), &[Token::Str(net_str)]);
-        assert_tokens(&net.compact(), &[
-            // This is too painful, but Token::Bytes() seems to be
-            // an array with a length, which is not what we serialize.
-            Token::Tuple { len: 17 },
-            Token::U8(253u8),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(0),
-            Token::U8(32),
-            Token::TupleEnd,
-        ]);
+        assert_tokens(
+            &net.compact(),
+            &[
+                // This is too painful, but Token::Bytes() seems to be
+                // an array with a length, which is not what we serialize.
+                Token::Tuple { len: 17 },
+                Token::U8(253u8),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(0),
+                Token::U8(32),
+                Token::TupleEnd,
+            ],
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! [`IpAddr`], [`Ipv4Addr`], and [`Ipv6Addr`] types already provided in
 //! Rust's standard library and align to their design to stay
 //! consistent.
-//! 
+//!
 //! The module also provides the [`IpSubnets`], [`Ipv4Subnets`], and
 //! [`Ipv6Subnets`] types for iterating over the subnets contained in
 //! an IP address range. The [`IpAddrRange`], [`Ipv4AddrRange`], and
@@ -61,7 +61,7 @@
 //!
 //! This library comes with support for [serde](https://serde.rs) but
 //! it's not enabled by default. Use the `serde` [feature] to enable.
-//! 
+//!
 //! ```toml
 //! [dependencies]
 //! ipnet = { version = "2", features = ["serde"] }
@@ -69,7 +69,7 @@
 //!
 //! For human readable formats (e.g. JSON) the `IpNet`, `Ipv4Net`, and
 //! `Ipv6Net` types will serialize to their `Display` strings.
-//! 
+//!
 //! For compact binary formats (e.g. Bincode) the `Ipv4Net` and
 //! `Ipv6Net` types will serialize to a string of 5 and 17 bytes that
 //! consist of the network address octects followed by the prefix
@@ -78,21 +78,33 @@
 //!
 //! [feature]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 
-#[cfg(feature = "serde")]
-extern crate serde;
+#![no_std]
+#![cfg_attr(not(feature = "std"), feature(error_in_core))]
+#![cfg_attr(not(feature = "std"), feature(ip_in_core))]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg_attr(test, macro_use)]
+extern crate alloc;
+
 #[cfg(feature = "schemars")]
 extern crate schemars;
+#[cfg(feature = "serde")]
+extern crate serde;
 
-pub use self::ipext::{IpAdd, IpSub, IpBitAnd, IpBitOr, IpAddrRange, Ipv4AddrRange, Ipv6AddrRange};
-pub use self::ipnet::{IpNet, Ipv4Net, Ipv6Net, PrefixLenError, IpSubnets, Ipv4Subnets, Ipv6Subnets};
-pub use self::parser::AddrParseError;
+pub use self::ipext::{IpAdd, IpAddrRange, IpBitAnd, IpBitOr, IpSub, Ipv4AddrRange, Ipv6AddrRange};
+pub use self::ipnet::{
+    IpNet, IpSubnets, Ipv4Net, Ipv4Subnets, Ipv6Net, Ipv6Subnets, PrefixLenError,
+};
 pub use self::mask::{ip_mask_to_prefix, ipv4_mask_to_prefix, ipv6_mask_to_prefix};
+pub use self::parser::AddrParseError;
 
 mod ipext;
 mod ipnet;
-mod parser;
-mod mask;
-#[cfg(feature = "serde")]
-mod ipnet_serde;
 #[cfg(feature = "schemars")]
 mod ipnet_schemars;
+#[cfg(feature = "serde")]
+mod ipnet_serde;
+mod mask;
+mod parser;

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -1,4 +1,7 @@
 use crate::PrefixLenError;
+#[cfg(not(feature = "std"))]
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+#[cfg(feature = "std")]
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 /// Converts a `IpAddr` network mask into a prefix.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,10 +4,17 @@
 //! is private. It is copied and extended here with methods for parsing
 //! IP network addresses.
 
+use alloc::boxed::Box;
+use alloc::str::FromStr;
+#[cfg(not(feature = "std"))]
+use core::error::Error;
+use core::fmt;
+#[cfg(not(feature = "std"))]
+use core::net::{Ipv4Addr, Ipv6Addr};
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::fmt;
+#[cfg(feature = "std")]
 use std::net::{Ipv4Addr, Ipv6Addr};
-use std::str::FromStr;
 
 use crate::ipnet::{IpNet, Ipv4Net, Ipv6Net};
 
@@ -30,7 +37,8 @@ impl<'a> Parser<'a> {
     }
 
     // Commit only if parser returns Some
-    fn read_atomically<T, F>(&mut self, cb: F) -> Option<T> where
+    fn read_atomically<T, F>(&mut self, cb: F) -> Option<T>
+    where
         F: FnOnce(&mut Parser) -> Option<T>,
     {
         let pos = self.pos;
@@ -42,20 +50,27 @@ impl<'a> Parser<'a> {
     }
 
     // Commit only if parser read till EOF
-    fn read_till_eof<T, F>(&mut self, cb: F) -> Option<T> where
+    fn read_till_eof<T, F>(&mut self, cb: F) -> Option<T>
+    where
         F: FnOnce(&mut Parser) -> Option<T>,
     {
-        self.read_atomically(move |p| {
-            match cb(p) {
-                Some(x) => if p.is_eof() {Some(x)} else {None},
-                None => None,
+        self.read_atomically(move |p| match cb(p) {
+            Some(x) => {
+                if p.is_eof() {
+                    Some(x)
+                } else {
+                    None
+                }
             }
+            None => None,
         })
     }
 
     // Return result of first successful parser
-    fn read_or<T>(&mut self, parsers: &mut [Box<dyn FnMut(&mut Parser) -> Option<T> + 'static>])
-               -> Option<T> {
+    fn read_or<T>(
+        &mut self,
+        parsers: &mut [Box<dyn FnMut(&mut Parser) -> Option<T> + 'static>],
+    ) -> Option<T> {
         for pf in parsers {
             if let Some(r) = self.read_atomically(|p: &mut Parser| pf(p)) {
                 return Some(r);
@@ -65,11 +80,8 @@ impl<'a> Parser<'a> {
     }
 
     // Apply 3 parsers sequentially
-    fn read_seq_3<A, B, C, PA, PB, PC>(&mut self,
-                                       pa: PA,
-                                       pb: PB,
-                                       pc: PC)
-                                       -> Option<(A, B, C)> where
+    fn read_seq_3<A, B, C, PA, PB, PC>(&mut self, pa: PA, pb: PB, pc: PC) -> Option<(A, B, C)>
+    where
         PA: FnOnce(&mut Parser) -> Option<A>,
         PB: FnOnce(&mut Parser) -> Option<B>,
         PC: FnOnce(&mut Parser) -> Option<C>,
@@ -80,7 +92,7 @@ impl<'a> Parser<'a> {
             let c = if b.is_some() { pc(p) } else { None };
             match (a, b, c) {
                 (Some(a), Some(b), Some(c)) => Some((a, b, c)),
-                _ => None
+                _ => None,
             }
         })
     }
@@ -98,11 +110,9 @@ impl<'a> Parser<'a> {
 
     // Return char and advance iff next char is equal to requested
     fn read_given_char(&mut self, c: char) -> Option<char> {
-        self.read_atomically(|p| {
-            match p.read_char() {
-                Some(next) if next == c => Some(next),
-                _ => None,
-            }
+        self.read_atomically(|p| match p.read_char() {
+            Some(next) if next == c => Some(next),
+            _ => None,
         })
     }
 
@@ -122,9 +132,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        self.read_atomically(|p| {
-            p.read_char().and_then(|c| parse_digit(c, radix))
-        })
+        self.read_atomically(|p| p.read_char().and_then(|c| parse_digit(c, radix)))
     }
 
     fn read_number_impl(&mut self, radix: u8, max_digits: u32, upto: u32) -> Option<u32> {
@@ -136,14 +144,14 @@ impl<'a> Parser<'a> {
                     r = r * (radix as u32) + (d as u32);
                     digit_count += 1;
                     if digit_count > max_digits || r >= upto {
-                        return None
+                        return None;
                     }
                 }
                 None => {
                     if digit_count == 0 {
-                        return None
+                        return None;
                     } else {
-                        return Some(r)
+                        return Some(r);
                     }
                 }
             };
@@ -183,12 +191,11 @@ impl<'a> Parser<'a> {
             assert!(head.len() + tail.len() <= 8);
             let mut gs = [0; 8];
             gs[..head.len()].copy_from_slice(head);
-            gs[(8 - tail.len()) .. 8].copy_from_slice(tail);
+            gs[(8 - tail.len())..8].copy_from_slice(tail);
             Ipv6Addr::new(gs[0], gs[1], gs[2], gs[3], gs[4], gs[5], gs[6], gs[7])
         }
 
-        fn read_groups(p: &mut Parser, groups: &mut [u16; 8], limit: usize)
-                       -> (usize, bool) {
+        fn read_groups(p: &mut Parser, groups: &mut [u16; 8], limit: usize) -> (usize, bool) {
             let mut i = 0;
             while i < limit {
                 if i < limit - 1 {
@@ -216,7 +223,7 @@ impl<'a> Parser<'a> {
                 });
                 match group {
                     Some(g) => groups[i] = g,
-                    None => return (i, false)
+                    None => return (i, false),
                 }
                 i += 1;
             }
@@ -228,13 +235,13 @@ impl<'a> Parser<'a> {
 
         if head_size == 8 {
             return Some(Ipv6Addr::new(
-                head[0], head[1], head[2], head[3],
-                head[4], head[5], head[6], head[7]))
+                head[0], head[1], head[2], head[3], head[4], head[5], head[6], head[7],
+            ));
         }
 
         // IPv4 part is not allowed before `::`
         if head_ipv4 {
-            return None
+            return None;
         }
 
         // read `::` if previous code parsed less than 8 groups
@@ -244,22 +251,23 @@ impl<'a> Parser<'a> {
 
         let mut tail = [0; 8];
         let (tail_size, _) = read_groups(self, &mut tail, 8 - head_size);
-        Some(ipv6_addr_from_head_tail(&head[..head_size], &tail[..tail_size]))
+        Some(ipv6_addr_from_head_tail(
+            &head[..head_size],
+            &tail[..tail_size],
+        ))
     }
 
     fn read_ipv6_addr(&mut self) -> Option<Ipv6Addr> {
         self.read_atomically(|p| p.read_ipv6_addr_impl())
     }
-    
+
     /* Additions for IpNet below. */
 
     // Read IPv4 network
     fn read_ipv4_net(&mut self) -> Option<Ipv4Net> {
         let ip_addr = |p: &mut Parser| p.read_ipv4_addr();
         let slash = |p: &mut Parser| p.read_given_char('/');
-        let prefix_len = |p: &mut Parser| {
-            p.read_number(10, 2, 33).map(|n| n as u8)
-        };
+        let prefix_len = |p: &mut Parser| p.read_number(10, 2, 33).map(|n| n as u8);
 
         self.read_seq_3(ip_addr, slash, prefix_len).map(|t| {
             let (ip, _, prefix_len): (Ipv4Addr, char, u8) = t;
@@ -271,9 +279,7 @@ impl<'a> Parser<'a> {
     fn read_ipv6_net(&mut self) -> Option<Ipv6Net> {
         let ip_addr = |p: &mut Parser| p.read_ipv6_addr();
         let slash = |p: &mut Parser| p.read_given_char('/');
-        let prefix_len = |p: &mut Parser| {
-            p.read_number(10, 3, 129).map(|n| n as u8)
-        };
+        let prefix_len = |p: &mut Parser| p.read_number(10, 3, 129).map(|n| n as u8);
 
         self.read_seq_3(ip_addr, slash, prefix_len).map(|t| {
             let (ip, _, prefix_len): (Ipv6Addr, char, u8) = t;
@@ -297,7 +303,7 @@ impl FromStr for IpNet {
     fn from_str(s: &str) -> Result<IpNet, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_ip_net()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError(()))
+            None => Err(AddrParseError(())),
         }
     }
 }
@@ -307,7 +313,7 @@ impl FromStr for Ipv4Net {
     fn from_str(s: &str) -> Result<Ipv4Net, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_ipv4_net()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError(()))
+            None => Err(AddrParseError(())),
         }
     }
 }
@@ -317,7 +323,7 @@ impl FromStr for Ipv6Net {
     fn from_str(s: &str) -> Result<Ipv6Net, AddrParseError> {
         match Parser::new(s).read_till_eof(|p| p.read_ipv6_net()) {
             Some(s) => Ok(s),
-            None => Err(AddrParseError(()))
+            None => Err(AddrParseError(())),
         }
     }
 }


### PR DESCRIPTION
This PR adds `no_std` support using the unstable `ip_in_core` and `error_in_core` features.