### PR TITLE
Add ser_as_str feature to serialize using serialize_str()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipnet"
-version = "2.8.0" # Remember to update html_root_url
+version = "2.9.0" # Remember to update html_root_url
 authors = ["Kris Price <kris@krisprice.nz>"]
 description = "Provides types and useful methods for working with IPv4 and IPv6 network addresses, commonly called IP prefixes. The new `IpNet`, `Ipv4Net`, and `Ipv6Net` types build on the existing `IpAddr`, `Ipv4Addr`, and `Ipv6Addr` types already provided in Rust's standard library and align to their design to stay consistent. The module also provides useful traits that extend `Ipv4Addr` and `Ipv6Addr` with methods for `Add`, `Sub`, `BitAnd`, and `BitOr` operations. The module only uses stable feature so it is guaranteed to compile using the stable toolchain."
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,12 @@ default = ["std"]
 std = []
 # Implements "schemars::JsonSchema". Also implies "serde".
 json = ["serde", "schemars"]
+ser_as_str = ["heapless"]
 
 [dependencies]
 serde = { package = "serde", version = "1", features = ["derive"], optional = true, default-features=false }
 schemars = { version = "0.8", optional = true }
+heapless = { version = "*", optional = true }
 
 [dev-dependencies]
 serde_test = "1"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Version 2.9.0
+
+*  Add ser_as_str feature to serialize using serialize_str() #52 
+
 ## Version 2.8.0
 
 * Add no_std support on nightly #51 

--- a/src/ipnet_serde.rs
+++ b/src/ipnet_serde.rs
@@ -84,6 +84,13 @@ impl Serialize for Ipv4Net {
         where S: Serializer
     {
         if serializer.is_human_readable() {
+            #[cfg(feature = "ser_as_str")]
+            {
+                let mut buf = heapless::String::<18>::new();
+                fmt::write(&mut buf, format_args!("{self}")).unwrap();
+                serializer.serialize_str(&buf)
+            }
+            #[cfg(not(feature = "ser_as_str"))]
             serializer.collect_str(self)
         } else {
             let mut seq = serializer.serialize_tuple(5)?;
@@ -130,6 +137,13 @@ impl Serialize for Ipv6Net {
         where S: Serializer
     {
         if serializer.is_human_readable() {
+            #[cfg(feature = "ser_as_str")]
+            {
+                let mut buf = heapless::String::<43>::new();
+                fmt::write(&mut buf, format_args!("{self}")).unwrap();
+                serializer.serialize_str(&buf)
+            }
+            #[cfg(not(feature = "ser_as_str"))]
             serializer.collect_str(self)
         } else {
             let mut seq = serializer.serialize_tuple(17)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/ipnet/2.8.0")]
+#![doc(html_root_url = "https://docs.rs/ipnet/2.9.0")]
 //! Types for IPv4 and IPv6 network addresses.
 //!
 //! This module provides types and useful methods for working with IPv4


### PR DESCRIPTION
I'm doing a lot of no_std firmware development, and frequently use serde_json_core crate.

This serializer does not support collect_str() used in ipnet's serialization code since 1096c55d6f0b95e06aaa21604c936e3093a40af7.

This patch adds new feature to enable serialization by formatting Ipv*Net addr to heapless::String and then serializing using serialize_str(). Since maximum formatted address length is fixed, and not too big, memory usage is still very low.