### PR TITLE
Remove nightly features for no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,6 @@
 //! [feature]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 
 #![no_std]
-#![cfg_attr(not(feature = "std"), feature(error_in_core))]
-#![cfg_attr(not(feature = "std"), feature(ip_in_core))]
 
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
Starting with Rust 1.81, `core::errors::Error` landed in stable:
https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html#coreerrorerror

`core::net` was already stabilized with 1.77.0.

This means we no longer need extra nightly features to build ipnet on `no_std`.