### PR TITLE
chore(fmt): rustfmt repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["network-programming"]
 readme = "README.md"
 documentation = "https://docs.rs/ipnet"
 edition = "2018"
+rust-version = "1.31"
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read the [documentation] for the full details. And find it on [Crates.io].
 
 ## Release 2.0 requirements
 
-Release 2.0 requires Rust 1.26 or later. Release 1.0 used a custom emulated 128-bit integer type (`Emu128`) to fully support IPv6 addresses. This has been replaced with Rust's built-in 128-bit integer, which is now stable as of Rust 1.26. There are reports of issues using Rust's 128-bit integers on some targets (e.g. Emscripten). If you have issues on your chosen target, please continue to use the 1.0 release until that has been resolved.
+Release 2.0 requires Rust 1.31 or later. Release 1.0 used a custom emulated 128-bit integer type (`Emu128`) to fully support IPv6 addresses. This has been replaced with Rust's built-in 128-bit integer, which is now stable as of Rust 1.26. There are reports of issues using Rust's 128-bit integers on some targets (e.g. Emscripten). If you have issues on your chosen target, please continue to use the 1.0 release until that has been resolved.
 
 ## Examples
 

--- a/src/ipext.rs
+++ b/src/ipext.rs
@@ -4,8 +4,8 @@
 //! the `Ipv4Addr` and `Ipv6Addr` types with methods to perform these
 //! operations.
 
-use core::cmp::Ordering::{Less, Equal};
-use core::iter::{FusedIterator, DoubleEndedIterator};
+use core::cmp::Ordering::{Equal, Less};
+use core::iter::{DoubleEndedIterator, FusedIterator};
 use core::mem;
 #[cfg(not(feature = "std"))]
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -78,7 +78,7 @@ pub trait IpAdd<RHS = Self> {
 /// assert_eq!(ip2.saturating_sub(ip1), 95);
 /// assert_eq!(min.saturating_sub(5), min);
 /// assert_eq!(ip2.saturating_sub(95), ip1);
-/// 
+///
 /// let min: Ipv6Addr = "::".parse().unwrap();
 /// let ip1: Ipv6Addr = "fd00::5".parse().unwrap();
 /// let ip2: Ipv6Addr = "fd00::64".parse().unwrap();
@@ -110,7 +110,7 @@ pub trait IpSub<RHS = Self> {
 ///
 /// assert_eq!(ip.bitand(mask), res);
 /// assert_eq!(ip.bitand(0xffff0000), res);
-/// 
+///
 /// let ip: Ipv6Addr = "fd00:1234::1".parse().unwrap();
 /// let mask: Ipv6Addr = "ffff::".parse().unwrap();
 /// let res: Ipv6Addr = "fd00::".parse().unwrap();
@@ -140,7 +140,7 @@ pub trait IpBitAnd<RHS = Self> {
 ///
 /// assert_eq!(ip.bitor(mask), res);
 /// assert_eq!(ip.bitor(0x000000ff), res);
-/// 
+///
 /// let ip: Ipv6Addr = "fd00::1".parse().unwrap();
 /// let mask: Ipv6Addr = "::ffff:ffff".parse().unwrap();
 /// let res: Ipv6Addr = "fd00::ffff:ffff".parse().unwrap();
@@ -154,7 +154,7 @@ pub trait IpBitOr<RHS = Self> {
 }
 
 macro_rules! ip_add_impl {
-    ($lhs:ty, $rhs:ty, $output:ty, $inner:ty) => (
+    ($lhs:ty, $rhs:ty, $output:ty, $inner:ty) => {
         impl IpAdd<$rhs> for $lhs {
             type Output = $output;
 
@@ -164,11 +164,11 @@ macro_rules! ip_add_impl {
                 (lhs.saturating_add(rhs.into())).into()
             }
         }
-    )
+    };
 }
 
 macro_rules! ip_sub_impl {
-    ($lhs:ty, $rhs:ty, $output:ty, $inner:ty) => (
+    ($lhs:ty, $rhs:ty, $output:ty, $inner:ty) => {
         impl IpSub<$rhs> for $lhs {
             type Output = $output;
 
@@ -178,7 +178,7 @@ macro_rules! ip_sub_impl {
                 (lhs.saturating_sub(rhs.into())).into()
             }
         }
-    )
+    };
 }
 
 ip_add_impl!(Ipv4Addr, u32, Ipv4Addr, u32);
@@ -333,7 +333,7 @@ pub struct Ipv4AddrRange {
 ///
 /// # Examples
 ///
-/// ``` 
+/// ```
 /// # #[cfg(not(feature = "std"))]
 /// # use core::net::Ipv6Addr;
 /// # #[cfg(feature = "std")]
@@ -385,7 +385,7 @@ impl Ipv4AddrRange {
                 let count: u32 = self.end.saturating_sub(self.start);
                 let count = count as u64 + 1; // Never overflows
                 count
-            },
+            }
             Some(Equal) => 1,
             _ => 0,
         }
@@ -408,7 +408,7 @@ impl Ipv6AddrRange {
                 let count = self.end.saturating_sub(self.start);
                 // May overflow or panic
                 count + 1
-            },
+            }
             Some(Equal) => 1,
             _ => 0,
         }
@@ -416,7 +416,10 @@ impl Ipv6AddrRange {
     /// True only if count_u128 does not overflow
     fn can_count_u128(&self) -> bool {
         self.start != Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)
-        || self.end != Ipv6Addr::new(0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff)
+            || self.end
+                != Ipv6Addr::new(
+                    0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
+                )
     }
 }
 
@@ -481,11 +484,11 @@ impl Iterator for Ipv4AddrRange {
             Some(Less) => {
                 let next = self.start.add_one();
                 Some(mem::replace(&mut self.start, next))
-            },
+            }
             Some(Equal) => {
                 self.end.replace_zero();
                 Some(self.start.replace_one())
-            },
+            }
             _ => None,
         }
     }
@@ -509,9 +512,9 @@ impl Iterator for Ipv4AddrRange {
                     // emulate standard overflow/panic behavior
                     core::usize::MAX + 2 + count as usize
                 }
-            },
+            }
             Some(Equal) => 1,
-            _ => 0
+            _ => 0,
         }
     }
 
@@ -529,7 +532,7 @@ impl Iterator for Ipv4AddrRange {
     fn min(self) -> Option<Self::Item> {
         match self.start.partial_cmp(&self.end) {
             Some(Less) | Some(Equal) => Some(self.start),
-            _ => None
+            _ => None,
         }
     }
 
@@ -569,11 +572,11 @@ impl Iterator for Ipv6AddrRange {
             Some(Less) => {
                 let next = self.start.add_one();
                 Some(mem::replace(&mut self.start, next))
-            },
+            }
             Some(Equal) => {
                 self.end.replace_zero();
                 Some(self.start.replace_one())
-            },
+            }
             _ => None,
         }
     }
@@ -605,7 +608,7 @@ impl Iterator for Ipv6AddrRange {
     fn min(self) -> Option<Self::Item> {
         match self.start.partial_cmp(&self.end) {
             Some(Less) | Some(Equal) => Some(self.start),
-            _ => None
+            _ => None,
         }
     }
 
@@ -670,12 +673,12 @@ impl DoubleEndedIterator for Ipv4AddrRange {
             Some(Less) => {
                 let next_back = self.end.sub_one();
                 Some(mem::replace(&mut self.end, next_back))
-            },
+            }
             Some(Equal) => {
                 self.end.replace_zero();
                 Some(self.start.replace_one())
-            },
-            _ => None
+            }
+            _ => None,
         }
     }
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
@@ -702,12 +705,12 @@ impl DoubleEndedIterator for Ipv6AddrRange {
             Some(Less) => {
                 let next_back = self.end.sub_one();
                 Some(mem::replace(&mut self.end, next_back))
-            },
+            }
             Some(Equal) => {
                 self.end.replace_zero();
                 Some(self.start.replace_one())
-            },
-            _ => None
+            }
+            _ => None,
         }
     }
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
@@ -718,8 +721,7 @@ impl DoubleEndedIterator for Ipv6AddrRange {
                 self.end.replace_zero();
                 self.start.replace_one();
                 None
-            }
-            else if n == count - 1 {
+            } else if n == count - 1 {
                 self.end.replace_zero();
                 Some(self.start.replace_one())
             } else {
@@ -743,28 +745,31 @@ impl FusedIterator for Ipv6AddrRange {}
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use alloc::vec::Vec;
-    use core::str::FromStr;
     #[cfg(not(feature = "std"))]
     use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use core::str::FromStr;
     #[cfg(feature = "std")]
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-    use super::*;
 
     #[test]
     fn test_ipaddrrange() {
         // Next, Next-Back
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap()
+            Ipv4Addr::from_str("10.0.0.3").unwrap(),
         );
 
-        assert_eq!(i.collect::<Vec<Ipv4Addr>>(), vec![
-            Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.1").unwrap(),
-            Ipv4Addr::from_str("10.0.0.2").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<Ipv4Addr>>(),
+            vec![
+                Ipv4Addr::from_str("10.0.0.0").unwrap(),
+                Ipv4Addr::from_str("10.0.0.1").unwrap(),
+                Ipv4Addr::from_str("10.0.0.2").unwrap(),
+                Ipv4Addr::from_str("10.0.0.3").unwrap(),
+            ]
+        );
 
         let mut v = i.collect::<Vec<_>>();
         v.reverse();
@@ -772,25 +777,31 @@ mod tests {
 
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("255.255.255.254").unwrap(),
-            Ipv4Addr::from_str("255.255.255.255").unwrap()
+            Ipv4Addr::from_str("255.255.255.255").unwrap(),
         );
 
-        assert_eq!(i.collect::<Vec<Ipv4Addr>>(), vec![
-            Ipv4Addr::from_str("255.255.255.254").unwrap(),
-            Ipv4Addr::from_str("255.255.255.255").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<Ipv4Addr>>(),
+            vec![
+                Ipv4Addr::from_str("255.255.255.254").unwrap(),
+                Ipv4Addr::from_str("255.255.255.255").unwrap(),
+            ]
+        );
 
         let i = Ipv6AddrRange::new(
             Ipv6Addr::from_str("fd00::").unwrap(),
             Ipv6Addr::from_str("fd00::3").unwrap(),
         );
 
-        assert_eq!(i.collect::<Vec<Ipv6Addr>>(), vec![
-            Ipv6Addr::from_str("fd00::").unwrap(),
-            Ipv6Addr::from_str("fd00::1").unwrap(),
-            Ipv6Addr::from_str("fd00::2").unwrap(),
-            Ipv6Addr::from_str("fd00::3").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<Ipv6Addr>>(),
+            vec![
+                Ipv6Addr::from_str("fd00::").unwrap(),
+                Ipv6Addr::from_str("fd00::1").unwrap(),
+                Ipv6Addr::from_str("fd00::2").unwrap(),
+                Ipv6Addr::from_str("fd00::3").unwrap(),
+            ]
+        );
 
         let mut v = i.collect::<Vec<_>>();
         v.reverse();
@@ -801,48 +812,60 @@ mod tests {
             Ipv6Addr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
         );
 
-        assert_eq!(i.collect::<Vec<Ipv6Addr>>(), vec![
-            Ipv6Addr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe").unwrap(),
-            Ipv6Addr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
-        ]);
-        
+        assert_eq!(
+            i.collect::<Vec<Ipv6Addr>>(),
+            vec![
+                Ipv6Addr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe").unwrap(),
+                Ipv6Addr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
+            ]
+        );
+
         let i = IpAddrRange::from(Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
             Ipv4Addr::from_str("10.0.0.3").unwrap(),
         ));
 
-        assert_eq!(i.collect::<Vec<IpAddr>>(), vec![
-            IpAddr::from_str("10.0.0.0").unwrap(),
-            IpAddr::from_str("10.0.0.1").unwrap(),
-            IpAddr::from_str("10.0.0.2").unwrap(),
-            IpAddr::from_str("10.0.0.3").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<IpAddr>>(),
+            vec![
+                IpAddr::from_str("10.0.0.0").unwrap(),
+                IpAddr::from_str("10.0.0.1").unwrap(),
+                IpAddr::from_str("10.0.0.2").unwrap(),
+                IpAddr::from_str("10.0.0.3").unwrap(),
+            ]
+        );
 
         let mut v = i.collect::<Vec<_>>();
         v.reverse();
         assert_eq!(v, i.rev().collect::<Vec<_>>());
-        
+
         let i = IpAddrRange::from(Ipv4AddrRange::new(
             Ipv4Addr::from_str("255.255.255.254").unwrap(),
-            Ipv4Addr::from_str("255.255.255.255").unwrap()
+            Ipv4Addr::from_str("255.255.255.255").unwrap(),
         ));
 
-        assert_eq!(i.collect::<Vec<IpAddr>>(), vec![
-            IpAddr::from_str("255.255.255.254").unwrap(),
-            IpAddr::from_str("255.255.255.255").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<IpAddr>>(),
+            vec![
+                IpAddr::from_str("255.255.255.254").unwrap(),
+                IpAddr::from_str("255.255.255.255").unwrap(),
+            ]
+        );
 
         let i = IpAddrRange::from(Ipv6AddrRange::new(
             Ipv6Addr::from_str("fd00::").unwrap(),
             Ipv6Addr::from_str("fd00::3").unwrap(),
         ));
 
-        assert_eq!(i.collect::<Vec<IpAddr>>(), vec![
-            IpAddr::from_str("fd00::").unwrap(),
-            IpAddr::from_str("fd00::1").unwrap(),
-            IpAddr::from_str("fd00::2").unwrap(),
-            IpAddr::from_str("fd00::3").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<IpAddr>>(),
+            vec![
+                IpAddr::from_str("fd00::").unwrap(),
+                IpAddr::from_str("fd00::1").unwrap(),
+                IpAddr::from_str("fd00::2").unwrap(),
+                IpAddr::from_str("fd00::3").unwrap(),
+            ]
+        );
 
         let mut v = i.collect::<Vec<_>>();
         v.reverse();
@@ -853,10 +876,13 @@ mod tests {
             Ipv6Addr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
         ));
 
-        assert_eq!(i.collect::<Vec<IpAddr>>(), vec![
-            IpAddr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe").unwrap(),
-            IpAddr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
-        ]);
+        assert_eq!(
+            i.collect::<Vec<IpAddr>>(),
+            vec![
+                IpAddr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe").unwrap(),
+                IpAddr::from_str("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").unwrap(),
+            ]
+        );
 
         // #11 (infinite iterator when start and stop are 0)
         let zero4 = Ipv4Addr::from_str("0.0.0.0").unwrap();
@@ -873,7 +899,7 @@ mod tests {
         // Count
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap()
+            Ipv4Addr::from_str("10.0.0.3").unwrap(),
         );
         assert_eq!(i.count(), 4);
 
@@ -886,7 +912,7 @@ mod tests {
         // Size Hint
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap()
+            Ipv4Addr::from_str("10.0.0.3").unwrap(),
         );
         assert_eq!(i.size_hint(), (4, Some(4)));
 
@@ -906,27 +932,45 @@ mod tests {
         // Min, Max, Last
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap()
+            Ipv4Addr::from_str("10.0.0.3").unwrap(),
         );
-        assert_eq!(Iterator::min(i), Some(Ipv4Addr::from_str("10.0.0.0").unwrap()));
-        assert_eq!(Iterator::max(i), Some(Ipv4Addr::from_str("10.0.0.3").unwrap()));
+        assert_eq!(
+            Iterator::min(i),
+            Some(Ipv4Addr::from_str("10.0.0.0").unwrap())
+        );
+        assert_eq!(
+            Iterator::max(i),
+            Some(Ipv4Addr::from_str("10.0.0.3").unwrap())
+        );
         assert_eq!(i.last(), Some(Ipv4Addr::from_str("10.0.0.3").unwrap()));
 
         let i = Ipv6AddrRange::new(
             Ipv6Addr::from_str("fd00::").unwrap(),
             Ipv6Addr::from_str("fd00::3").unwrap(),
         );
-        assert_eq!(Iterator::min(i), Some(Ipv6Addr::from_str("fd00::").unwrap()));
-        assert_eq!(Iterator::max(i), Some(Ipv6Addr::from_str("fd00::3").unwrap()));
+        assert_eq!(
+            Iterator::min(i),
+            Some(Ipv6Addr::from_str("fd00::").unwrap())
+        );
+        assert_eq!(
+            Iterator::max(i),
+            Some(Ipv6Addr::from_str("fd00::3").unwrap())
+        );
         assert_eq!(i.last(), Some(Ipv6Addr::from_str("fd00::3").unwrap()));
 
         // Nth
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap()
+            Ipv4Addr::from_str("10.0.0.3").unwrap(),
         );
-        assert_eq!(i.clone().nth(0), Some(Ipv4Addr::from_str("10.0.0.0").unwrap()));
-        assert_eq!(i.clone().nth(3), Some(Ipv4Addr::from_str("10.0.0.3").unwrap()));
+        assert_eq!(
+            i.clone().nth(0),
+            Some(Ipv4Addr::from_str("10.0.0.0").unwrap())
+        );
+        assert_eq!(
+            i.clone().nth(3),
+            Some(Ipv4Addr::from_str("10.0.0.3").unwrap())
+        );
         assert_eq!(i.clone().nth(4), None);
         assert_eq!(i.clone().nth(99), None);
         let mut i2 = i.clone();
@@ -941,8 +985,14 @@ mod tests {
             Ipv6Addr::from_str("fd00::").unwrap(),
             Ipv6Addr::from_str("fd00::3").unwrap(),
         );
-        assert_eq!(i.clone().nth(0), Some(Ipv6Addr::from_str("fd00::").unwrap()));
-        assert_eq!(i.clone().nth(3), Some(Ipv6Addr::from_str("fd00::3").unwrap()));
+        assert_eq!(
+            i.clone().nth(0),
+            Some(Ipv6Addr::from_str("fd00::").unwrap())
+        );
+        assert_eq!(
+            i.clone().nth(3),
+            Some(Ipv6Addr::from_str("fd00::3").unwrap())
+        );
         assert_eq!(i.clone().nth(4), None);
         assert_eq!(i.clone().nth(99), None);
         let mut i2 = i.clone();
@@ -956,15 +1006,27 @@ mod tests {
         // Nth Back
         let i = Ipv4AddrRange::new(
             Ipv4Addr::from_str("10.0.0.0").unwrap(),
-            Ipv4Addr::from_str("10.0.0.3").unwrap()
+            Ipv4Addr::from_str("10.0.0.3").unwrap(),
         );
-        assert_eq!(i.clone().nth_back(0), Some(Ipv4Addr::from_str("10.0.0.3").unwrap()));
-        assert_eq!(i.clone().nth_back(3), Some(Ipv4Addr::from_str("10.0.0.0").unwrap()));
+        assert_eq!(
+            i.clone().nth_back(0),
+            Some(Ipv4Addr::from_str("10.0.0.3").unwrap())
+        );
+        assert_eq!(
+            i.clone().nth_back(3),
+            Some(Ipv4Addr::from_str("10.0.0.0").unwrap())
+        );
         assert_eq!(i.clone().nth_back(4), None);
         assert_eq!(i.clone().nth_back(99), None);
         let mut i2 = i.clone();
-        assert_eq!(i2.nth_back(1), Some(Ipv4Addr::from_str("10.0.0.2").unwrap()));
-        assert_eq!(i2.nth_back(1), Some(Ipv4Addr::from_str("10.0.0.0").unwrap()));
+        assert_eq!(
+            i2.nth_back(1),
+            Some(Ipv4Addr::from_str("10.0.0.2").unwrap())
+        );
+        assert_eq!(
+            i2.nth_back(1),
+            Some(Ipv4Addr::from_str("10.0.0.0").unwrap())
+        );
         assert_eq!(i2.nth_back(0), None);
         let mut i3 = i.clone();
         assert_eq!(i3.nth_back(99), None);
@@ -974,8 +1036,14 @@ mod tests {
             Ipv6Addr::from_str("fd00::").unwrap(),
             Ipv6Addr::from_str("fd00::3").unwrap(),
         );
-        assert_eq!(i.clone().nth_back(0), Some(Ipv6Addr::from_str("fd00::3").unwrap()));
-        assert_eq!(i.clone().nth_back(3), Some(Ipv6Addr::from_str("fd00::").unwrap()));
+        assert_eq!(
+            i.clone().nth_back(0),
+            Some(Ipv6Addr::from_str("fd00::3").unwrap())
+        );
+        assert_eq!(
+            i.clone().nth_back(3),
+            Some(Ipv6Addr::from_str("fd00::").unwrap())
+        );
         assert_eq!(i.clone().nth_back(4), None);
         assert_eq!(i.clone().nth_back(99), None);
         let mut i2 = i.clone();

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -1,20 +1,20 @@
 use alloc::vec::Vec;
-use core::cmp::{min, max};
-use core::cmp::Ordering::{Less, Equal};
+use core::cmp::Ordering::{Equal, Less};
+use core::cmp::{max, min};
 use core::convert::From;
-use core::fmt;
-use core::iter::FusedIterator;
-use core::option::Option::{Some, None};
 #[cfg(not(feature = "std"))]
 use core::error::Error;
-#[cfg(feature = "std")]
-use std::error::Error;
+use core::fmt;
+use core::iter::FusedIterator;
 #[cfg(not(feature = "std"))]
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use core::option::Option::{None, Some};
+#[cfg(feature = "std")]
+use std::error::Error;
 #[cfg(feature = "std")]
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use crate::ipext::{IpAdd, IpSub, IpStep, IpAddrRange, Ipv4AddrRange, Ipv6AddrRange};
+use crate::ipext::{IpAdd, IpAddrRange, IpStep, IpSub, Ipv4AddrRange, Ipv6AddrRange};
 use crate::mask::{ip_mask_to_prefix, ipv4_mask_to_prefix, ipv6_mask_to_prefix};
 
 /// An IP network address, either IPv4 or IPv6.
@@ -142,7 +142,7 @@ impl IpNet {
     ///
     /// let net = IpNet::new(Ipv6Addr::LOCALHOST.into(), 48);
     /// assert!(net.is_ok());
-    /// 
+    ///
     /// let bad_prefix_len = IpNet::new(Ipv6Addr::LOCALHOST.into(), 129);
     /// assert_eq!(bad_prefix_len, Err(PrefixLenError));
     /// ```
@@ -294,7 +294,7 @@ impl IpNet {
             IpNet::V6(ref a) => IpAddr::V6(a.hostmask()),
         }
     }
-    
+
     /// Returns the network address.
     ///
     /// # Examples
@@ -314,8 +314,8 @@ impl IpNet {
             IpNet::V4(ref a) => IpAddr::V4(a.network()),
             IpNet::V6(ref a) => IpAddr::V6(a.network()),
         }
-    }    
-    
+    }
+
     /// Returns the broadcast address.
     ///
     /// # Examples
@@ -336,7 +336,7 @@ impl IpNet {
             IpNet::V6(ref a) => IpAddr::V6(a.broadcast()),
         }
     }
-    
+
     /// Returns the `IpNet` that contains this one.
     ///
     /// # Examples
@@ -365,7 +365,7 @@ impl IpNet {
         }
     }
 
-    /// Returns `true` if this network and the given network are 
+    /// Returns `true` if this network and the given network are
     /// children of the same supernet.
     ///
     /// # Examples
@@ -428,7 +428,7 @@ impl IpNet {
             IpNet::V6(ref a) => IpAddrRange::V6(a.hosts()),
         }
     }
-    
+
     /// Returns an `Iterator` over the subnets of this network with the
     /// given prefix length.
     ///
@@ -511,7 +511,10 @@ impl IpNet {
     /// assert!(!net4.contains(&ip6_no));
     /// assert!(!net6.contains(&ip4_no));
     /// ```
-    pub fn contains<T>(&self, other: T) -> bool where Self: Contains<T> {
+    pub fn contains<T>(&self, other: T) -> bool
+    where
+        Self: Contains<T>,
+    {
         Contains::contains(self, other)
     }
 
@@ -625,7 +628,10 @@ impl Ipv4Net {
         if prefix_len > 32 {
             return Err(PrefixLenError);
         }
-        Ok(Ipv4Net { addr: ip, prefix_len: prefix_len })
+        Ok(Ipv4Net {
+            addr: ip,
+            prefix_len: prefix_len,
+        })
     }
 
     /// Creates a new IPv4 network address from an `Ipv4Addr` and prefix
@@ -655,8 +661,14 @@ impl Ipv4Net {
     /// ```
     #[inline]
     pub const fn new_assert(ip: Ipv4Addr, prefix_len: u8) -> Ipv4Net {
-        assert!(prefix_len <= 32, "PREFIX_LEN must be less then or equal to 32 for Ipv4Net");
-        Ipv4Net { addr: ip, prefix_len: prefix_len }
+        assert!(
+            prefix_len <= 32,
+            "PREFIX_LEN must be less then or equal to 32 for Ipv4Net"
+        );
+        Ipv4Net {
+            addr: ip,
+            prefix_len: prefix_len,
+        }
     }
 
     /// Creates a new IPv4 network address from an `Ipv4Addr` and netmask.
@@ -712,7 +724,7 @@ impl Ipv4Net {
     pub const fn max_prefix_len(&self) -> u8 {
         32
     }
-    
+
     /// Returns the network mask.
     ///
     /// # Examples
@@ -729,7 +741,9 @@ impl Ipv4Net {
     }
 
     fn netmask_u32(&self) -> u32 {
-        u32::max_value().checked_shl(32 - self.prefix_len as u32).unwrap_or(0)
+        u32::max_value()
+            .checked_shl(32 - self.prefix_len as u32)
+            .unwrap_or(0)
     }
 
     /// Returns the host mask.
@@ -748,7 +762,9 @@ impl Ipv4Net {
     }
 
     fn hostmask_u32(&self) -> u32 {
-        u32::max_value().checked_shr(self.prefix_len as u32).unwrap_or(0)
+        u32::max_value()
+            .checked_shr(self.prefix_len as u32)
+            .unwrap_or(0)
     }
 
     /// Returns the network address.
@@ -796,10 +812,12 @@ impl Ipv4Net {
     /// assert_eq!(n3.supernet(), None);
     /// ```
     pub fn supernet(&self) -> Option<Ipv4Net> {
-        Ipv4Net::new(self.addr, self.prefix_len.wrapping_sub(1)).map(|n| n.trunc()).ok()
+        Ipv4Net::new(self.addr, self.prefix_len.wrapping_sub(1))
+            .map(|n| n.trunc())
+            .ok()
     }
 
-    /// Returns `true` if this network and the given network are 
+    /// Returns `true` if this network and the given network are
     /// children of the same supernet.
     ///
     /// # Examples
@@ -815,11 +833,11 @@ impl Ipv4Net {
     /// assert!(!n2.is_sibling(&n3));
     /// ```
     pub fn is_sibling(&self, other: &Ipv4Net) -> bool {
-        self.prefix_len > 0 &&
-        self.prefix_len == other.prefix_len &&
-        self.supernet().unwrap().contains(other)
+        self.prefix_len > 0
+            && self.prefix_len == other.prefix_len
+            && self.supernet().unwrap().contains(other)
     }
-    
+
     /// Return an `Iterator` over the host addresses in this network.
     ///
     /// If the prefix length is less than 31 both the network address
@@ -847,12 +865,12 @@ impl Ipv4Net {
     pub fn hosts(&self) -> Ipv4AddrRange {
         let mut start = self.network();
         let mut end = self.broadcast();
-        
+
         if self.prefix_len < 31 {
             start = start.saturating_add(1);
             end = end.saturating_sub(1);
         }
-        
+
         Ipv4AddrRange::new(start, end)
     }
 
@@ -890,7 +908,7 @@ impl Ipv4Net {
         if self.prefix_len > new_prefix_len || new_prefix_len > 32 {
             return Err(PrefixLenError);
         }
-        
+
         Ok(Ipv4Subnets::new(
             self.network(),
             self.broadcast(),
@@ -919,7 +937,10 @@ impl Ipv4Net {
     /// assert!(net.contains(&ip_yes));
     /// assert!(!net.contains(&ip_no));
     /// ```
-    pub fn contains<T>(&self, other: T) -> bool where Self: Contains<T> {
+    pub fn contains<T>(&self, other: T) -> bool
+    where
+        Self: Contains<T>,
+    {
         Contains::contains(self, other)
     }
 
@@ -953,7 +974,7 @@ impl Ipv4Net {
         let mut intervals: Vec<(_, _)> = networks.iter().map(|n| n.interval()).collect();
         intervals = merge_intervals(intervals);
         let mut res: Vec<Ipv4Net> = Vec::new();
-        
+
         for (start, mut end) in intervals {
             if end != core::u32::MAX {
                 end = end.saturating_sub(1)
@@ -988,11 +1009,14 @@ impl fmt::Display for Ipv4Net {
 
 impl From<Ipv4Addr> for Ipv4Net {
     fn from(addr: Ipv4Addr) -> Ipv4Net {
-        Ipv4Net { addr, prefix_len: 32 }
+        Ipv4Net {
+            addr,
+            prefix_len: 32,
+        }
     }
 }
 
-impl Ipv6Net {    
+impl Ipv6Net {
     /// Creates a new IPv6 network address from an `Ipv6Addr` and prefix
     /// length.
     ///
@@ -1013,7 +1037,10 @@ impl Ipv6Net {
         if prefix_len > 128 {
             return Err(PrefixLenError);
         }
-        Ok(Ipv6Net { addr: ip, prefix_len: prefix_len })
+        Ok(Ipv6Net {
+            addr: ip,
+            prefix_len: prefix_len,
+        })
     }
 
     /// Creates a new IPv6 network address from an `Ipv6Addr` and prefix
@@ -1043,8 +1070,14 @@ impl Ipv6Net {
     /// ```
     #[inline]
     pub const fn new_assert(ip: Ipv6Addr, prefix_len: u8) -> Ipv6Net {
-        assert!(prefix_len <= 128, "PREFIX_LEN must be less then or equal to 128 for Ipv6Net");
-        Ipv6Net { addr: ip, prefix_len: prefix_len }
+        assert!(
+            prefix_len <= 128,
+            "PREFIX_LEN must be less then or equal to 128 for Ipv6Net"
+        );
+        Ipv6Net {
+            addr: ip,
+            prefix_len: prefix_len,
+        }
     }
 
     /// Creates a new IPv6 network address from an `Ipv6Addr` and netmask.
@@ -1082,7 +1115,7 @@ impl Ipv6Net {
     pub fn trunc(&self) -> Ipv6Net {
         Ipv6Net::new(self.network(), self.prefix_len).unwrap()
     }
-    
+
     /// Returns the address.
     #[inline]
     pub const fn addr(&self) -> Ipv6Addr {
@@ -1094,7 +1127,7 @@ impl Ipv6Net {
     pub const fn prefix_len(&self) -> u8 {
         self.prefix_len
     }
-    
+
     /// Returns the maximum valid prefix length.
     #[inline]
     pub const fn max_prefix_len(&self) -> u8 {
@@ -1117,7 +1150,9 @@ impl Ipv6Net {
     }
 
     fn netmask_u128(&self) -> u128 {
-        u128::max_value().checked_shl((128 - self.prefix_len) as u32).unwrap_or(u128::min_value())
+        u128::max_value()
+            .checked_shl((128 - self.prefix_len) as u32)
+            .unwrap_or(u128::min_value())
     }
 
     /// Returns the host mask.
@@ -1136,7 +1171,9 @@ impl Ipv6Net {
     }
 
     fn hostmask_u128(&self) -> u128 {
-        u128::max_value().checked_shr(self.prefix_len as u32).unwrap_or(u128::min_value())
+        u128::max_value()
+            .checked_shr(self.prefix_len as u32)
+            .unwrap_or(u128::min_value())
     }
 
     /// Returns the network address.
@@ -1153,7 +1190,7 @@ impl Ipv6Net {
     pub fn network(&self) -> Ipv6Addr {
         (u128::from(self.addr) & self.netmask_u128()).into()
     }
-    
+
     /// Returns the last address.
     ///
     /// Technically there is no such thing as a broadcast address for
@@ -1188,10 +1225,12 @@ impl Ipv6Net {
     /// assert_eq!(n3.supernet(), None);
     /// ```
     pub fn supernet(&self) -> Option<Ipv6Net> {
-        Ipv6Net::new(self.addr, self.prefix_len.wrapping_sub(1)).map(|n| n.trunc()).ok()
+        Ipv6Net::new(self.addr, self.prefix_len.wrapping_sub(1))
+            .map(|n| n.trunc())
+            .ok()
     }
 
-    /// Returns `true` if this network and the given network are 
+    /// Returns `true` if this network and the given network are
     /// children of the same supernet.
     ///
     /// # Examples
@@ -1207,11 +1246,11 @@ impl Ipv6Net {
     /// assert!(!n2.is_sibling(&n3));
     /// ```
     pub fn is_sibling(&self, other: &Ipv6Net) -> bool {
-        self.prefix_len > 0 &&
-        self.prefix_len == other.prefix_len &&
-        self.supernet().unwrap().contains(other)
+        self.prefix_len > 0
+            && self.prefix_len == other.prefix_len
+            && self.supernet().unwrap().contains(other)
     }
-    
+
     /// Return an `Iterator` over the host addresses in this network.
     ///
     /// # Examples
@@ -1266,7 +1305,7 @@ impl Ipv6Net {
         if self.prefix_len > new_prefix_len || new_prefix_len > 128 {
             return Err(PrefixLenError);
         }
-        
+
         Ok(Ipv6Subnets::new(
             self.network(),
             self.broadcast(),
@@ -1295,7 +1334,10 @@ impl Ipv6Net {
     /// assert!(net.contains(&ip_yes));
     /// assert!(!net.contains(&ip_no));
     /// ```
-    pub fn contains<T>(&self, other: T) -> bool where Self: Contains<T> {
+    pub fn contains<T>(&self, other: T) -> bool
+    where
+        Self: Contains<T>,
+    {
         Contains::contains(self, other)
     }
 
@@ -1364,7 +1406,10 @@ impl fmt::Display for Ipv6Net {
 
 impl From<Ipv6Addr> for Ipv6Net {
     fn from(addr: Ipv6Addr) -> Ipv6Net {
-        Ipv6Net { addr, prefix_len: 128 }
+        Ipv6Net {
+            addr,
+            prefix_len: 128,
+        }
     }
 }
 
@@ -1469,7 +1514,7 @@ impl<'a> Contains<&'a Ipv6Addr> for Ipv6Net {
 ///     "10.0.0.239".parse().unwrap(),
 ///     26,
 /// ));
-/// 
+///
 /// assert_eq!(subnets.collect::<Vec<IpNet>>(), vec![
 ///     "10.0.0.0/26".parse().unwrap(),
 ///     "10.0.0.64/26".parse().unwrap(),
@@ -1483,7 +1528,7 @@ impl<'a> Contains<&'a Ipv6Addr> for Ipv6Net {
 ///     "fd00:ef:ffff:ffff:ffff:ffff:ffff:ffff".parse().unwrap(),
 ///     26,
 /// ));
-/// 
+///
 /// assert_eq!(subnets.collect::<Vec<IpNet>>(), vec![
 ///     "fd00::/26".parse().unwrap(),
 ///     "fd00:40::/26".parse().unwrap(),
@@ -1516,7 +1561,7 @@ pub enum IpSubnets {
 ///     "10.0.0.239".parse().unwrap(),
 ///     26,
 /// );
-/// 
+///
 /// assert_eq!(subnets.collect::<Vec<Ipv4Net>>(), vec![
 ///     "10.0.0.0/26".parse().unwrap(),
 ///     "10.0.0.64/26".parse().unwrap(),
@@ -1550,7 +1595,7 @@ pub struct Ipv4Subnets {
 ///     "fd00:ef:ffff:ffff:ffff:ffff:ffff:ffff".parse().unwrap(),
 ///     26,
 /// );
-/// 
+///
 /// assert_eq!(subnets.collect::<Vec<Ipv6Net>>(), vec![
 ///     "fd00::/26".parse().unwrap(),
 ///     "fd00:40::/26".parse().unwrap(),
@@ -1613,9 +1658,10 @@ fn next_ipv4_subnet(start: Ipv4Addr, end: Ipv4Addr, min_prefix_len: u8) -> Ipv4N
     let range = end.saturating_sub(start).saturating_add(1);
     if range == core::u32::MAX && min_prefix_len == 0 {
         Ipv4Net::new(start, min_prefix_len).unwrap()
-    }
-    else {
-        let range_bits = 32u32.saturating_sub(range.leading_zeros()).saturating_sub(1);
+    } else {
+        let range_bits = 32u32
+            .saturating_sub(range.leading_zeros())
+            .saturating_sub(1);
         let start_tz = u32::from(start).trailing_zeros();
         let new_prefix_len = 32 - min(range_bits, start_tz);
         let next_prefix_len = max(new_prefix_len as u8, min_prefix_len);
@@ -1627,10 +1673,11 @@ fn next_ipv6_subnet(start: Ipv6Addr, end: Ipv6Addr, min_prefix_len: u8) -> Ipv6N
     let range = end.saturating_sub(start).saturating_add(1);
     if range == core::u128::MAX && min_prefix_len == 0 {
         Ipv6Net::new(start, min_prefix_len).unwrap()
-    }
-    else {
+    } else {
         let range = end.saturating_sub(start).saturating_add(1);
-        let range_bits = 128u32.saturating_sub(range.leading_zeros()).saturating_sub(1);
+        let range_bits = 128u32
+            .saturating_sub(range.leading_zeros())
+            .saturating_sub(1);
         let start_tz = u128::from(start).trailing_zeros();
         let new_prefix_len = 128 - min(range_bits, start_tz);
         let next_prefix_len = max(new_prefix_len as u8, min_prefix_len);
@@ -1655,13 +1702,13 @@ impl Iterator for Ipv4Subnets {
                     self.end.replace_zero();
                 }
                 Some(next)
-            },
+            }
             Some(Equal) => {
                 let next = next_ipv4_subnet(self.start, self.end, self.min_prefix_len);
                 self.start = next.broadcast().saturating_add(1);
                 self.end.replace_zero();
                 Some(next)
-            },
+            }
             _ => None,
         }
     }
@@ -1684,13 +1731,13 @@ impl Iterator for Ipv6Subnets {
                     self.end.replace_zero();
                 }
                 Some(next)
-            },
+            }
             Some(Equal) => {
                 let next = next_ipv6_subnet(self.start, self.end, self.min_prefix_len);
                 self.start = next.broadcast().saturating_add(1);
                 self.end.replace_zero();
                 Some(next)
-            },
+            }
             _ => None,
         }
     }
@@ -1709,7 +1756,7 @@ fn merge_intervals<T: Copy + Ord>(mut intervals: Vec<(T, T)>) -> Vec<(T, T)> {
     intervals.sort();
     let mut res: Vec<(T, T)> = Vec::new();
     let (mut start, mut end) = intervals[0];
-    
+
     let mut i = 1;
     let len = intervals.len();
     while i < len {
@@ -1717,8 +1764,7 @@ fn merge_intervals<T: Copy + Ord>(mut intervals: Vec<(T, T)>) -> Vec<(T, T)> {
         if end >= next_start {
             start = min(start, next_start);
             end = max(end, next_end);
-        }
-        else {
+        } else {
             res.push((start, end));
             start = next_start;
             end = next_end;
@@ -1743,8 +1789,12 @@ mod tests {
     fn test_make_ipnet_vec() {
         assert_eq!(
             make_ipnet_vec![
-                "10.1.1.1/32", "10.2.2.2/24", "10.3.3.3/16",
-                "fd00::1/128", "fd00::2/127", "fd00::3/126",
+                "10.1.1.1/32",
+                "10.2.2.2/24",
+                "10.3.3.3/16",
+                "fd00::1/128",
+                "fd00::2/127",
+                "fd00::3/126",
             ],
             vec![
                 "10.1.1.1/32".parse().unwrap(),
@@ -1760,26 +1810,28 @@ mod tests {
     #[test]
     fn test_merge_intervals() {
         let v = vec![
-            (0, 1), (1, 2), (2, 3),
-            (11, 12), (13, 14), (10, 15), (11, 13),
-            (20, 25), (24, 29),
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (11, 12),
+            (13, 14),
+            (10, 15),
+            (11, 13),
+            (20, 25),
+            (24, 29),
         ];
 
-        let v_ok = vec![
-            (0, 3),
-            (10, 15),
-            (20, 29),
-        ];
+        let v_ok = vec![(0, 3), (10, 15), (20, 29)];
 
         let vv = vec![
-            ([0, 1], [0, 2]), ([0, 2], [0, 3]), ([0, 0], [0, 1]),
-            ([10, 15], [11, 0]), ([10, 0], [10, 16]),
+            ([0, 1], [0, 2]),
+            ([0, 2], [0, 3]),
+            ([0, 0], [0, 1]),
+            ([10, 15], [11, 0]),
+            ([10, 0], [10, 16]),
         ];
 
-        let vv_ok = vec![
-            ([0, 0], [0, 3]),
-            ([10, 0], [11, 0]),
-        ];
+        let vv_ok = vec![([0, 0], [0, 3]), ([10, 0], [11, 0])];
 
         assert_eq!(merge_intervals(v), v_ok);
         assert_eq!(merge_intervals(vv), vv_ok);
@@ -1823,88 +1875,81 @@ mod tests {
 
     make_ipv4_subnets_test!(
         test_ipv4_subnets_zero_zero,
-        "0.0.0.0", "0.0.0.0", 0,
+        "0.0.0.0",
+        "0.0.0.0",
+        0,
         "0.0.0.0/32",
     );
 
     make_ipv4_subnets_test!(
         test_ipv4_subnets_zero_max,
-        "0.0.0.0", "255.255.255.255", 0,
+        "0.0.0.0",
+        "255.255.255.255",
+        0,
         "0.0.0.0/0",
     );
 
     make_ipv4_subnets_test!(
         test_ipv4_subnets_max_max,
-        "255.255.255.255", "255.255.255.255", 0,
+        "255.255.255.255",
+        "255.255.255.255",
+        0,
         "255.255.255.255/32",
     );
-    
-    make_ipv4_subnets_test!(
-        test_ipv4_subnets_none,
-        "0.0.0.1", "0.0.0.0", 0,
-    );
-    
-    make_ipv4_subnets_test!(
-        test_ipv4_subnets_one,
-        "0.0.0.0", "0.0.0.1", 0,
-        "0.0.0.0/31",
-    );
+
+    make_ipv4_subnets_test!(test_ipv4_subnets_none, "0.0.0.1", "0.0.0.0", 0,);
+
+    make_ipv4_subnets_test!(test_ipv4_subnets_one, "0.0.0.0", "0.0.0.1", 0, "0.0.0.0/31",);
 
     make_ipv4_subnets_test!(
         test_ipv4_subnets_two,
-        "0.0.0.0", "0.0.0.2", 0,
+        "0.0.0.0",
+        "0.0.0.2",
+        0,
         "0.0.0.0/31",
         "0.0.0.2/32",
     );
-    
+
     make_ipv4_subnets_test!(
         test_ipv4_subnets_taper,
-        "0.0.0.0", "0.0.0.10", 30,
+        "0.0.0.0",
+        "0.0.0.10",
+        30,
         "0.0.0.0/30",
         "0.0.0.4/30",
         "0.0.0.8/31",
         "0.0.0.10/32",
     );
-    
-    make_ipv6_subnets_test!(
-        test_ipv6_subnets_zero_zero,
-        "::", "::", 0,
-        "::/128",
-    );
+
+    make_ipv6_subnets_test!(test_ipv6_subnets_zero_zero, "::", "::", 0, "::/128",);
 
     make_ipv6_subnets_test!(
         test_ipv6_subnets_zero_max,
-        "::", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", 0,
+        "::",
+        "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        0,
         "::/0",
     );
 
     make_ipv6_subnets_test!(
         test_ipv6_subnets_max_max,
-        "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", 0,
+        "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        0,
         "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128",
     );
-    
-    make_ipv6_subnets_test!(
-        test_ipv6_subnets_none,
-        "::1", "::", 0,
-    );
-    
-    make_ipv6_subnets_test!(
-        test_ipv6_subnets_one,
-        "::", "::1", 0,
-        "::/127",
-    );
 
-    make_ipv6_subnets_test!(
-        test_ipv6_subnets_two,
-        "::", "::2", 0,
-        "::/127",
-        "::2/128",
-    );
+    make_ipv6_subnets_test!(test_ipv6_subnets_none, "::1", "::", 0,);
+
+    make_ipv6_subnets_test!(test_ipv6_subnets_one, "::", "::1", 0, "::/127",);
+
+    make_ipv6_subnets_test!(test_ipv6_subnets_two, "::", "::2", 0, "::/127", "::2/128",);
 
     make_ipv6_subnets_test!(
         test_ipv6_subnets_taper,
-        "::", "::a", 126,
+        "::",
+        "::a",
+        126,
         "::/126",
         "::4/126",
         "::8/127",
@@ -1914,11 +1959,19 @@ mod tests {
     #[test]
     fn test_aggregate() {
         let ip_nets = make_ipnet_vec![
-            "10.0.0.0/24", "10.0.1.0/24", "10.0.1.1/24", "10.0.1.2/24",
+            "10.0.0.0/24",
+            "10.0.1.0/24",
+            "10.0.1.1/24",
+            "10.0.1.2/24",
             "10.0.2.0/24",
-            "10.1.0.0/24", "10.1.1.0/24",
-            "192.168.0.0/24", "192.168.1.0/24", "192.168.2.0/24", "192.168.3.0/24",
-            "fd00::/32", "fd00:1::/32",
+            "10.1.0.0/24",
+            "10.1.1.0/24",
+            "192.168.0.0/24",
+            "192.168.1.0/24",
+            "192.168.2.0/24",
+            "192.168.3.0/24",
+            "fd00::/32",
+            "fd00:1::/32",
             "fd00:2::/32",
         ];
 
@@ -1931,23 +1984,38 @@ mod tests {
             "fd00:2::/32",
         ];
 
-        let ipv4_nets: Vec<Ipv4Net> = ip_nets.iter().filter_map(|p| if let IpNet::V4(x) = *p { Some(x) } else { None }).collect();
-        let ipv4_aggs: Vec<Ipv4Net> = ip_aggs.iter().filter_map(|p| if let IpNet::V4(x) = *p { Some(x) } else { None }).collect();
-        let ipv6_nets: Vec<Ipv6Net> = ip_nets.iter().filter_map(|p| if let IpNet::V6(x) = *p { Some(x) } else { None }).collect();
-        let ipv6_aggs: Vec<Ipv6Net> = ip_aggs.iter().filter_map(|p| if let IpNet::V6(x) = *p { Some(x) } else { None }).collect();
+        let ipv4_nets: Vec<Ipv4Net> = ip_nets
+            .iter()
+            .filter_map(|p| if let IpNet::V4(x) = *p { Some(x) } else { None })
+            .collect();
+        let ipv4_aggs: Vec<Ipv4Net> = ip_aggs
+            .iter()
+            .filter_map(|p| if let IpNet::V4(x) = *p { Some(x) } else { None })
+            .collect();
+        let ipv6_nets: Vec<Ipv6Net> = ip_nets
+            .iter()
+            .filter_map(|p| if let IpNet::V6(x) = *p { Some(x) } else { None })
+            .collect();
+        let ipv6_aggs: Vec<Ipv6Net> = ip_aggs
+            .iter()
+            .filter_map(|p| if let IpNet::V6(x) = *p { Some(x) } else { None })
+            .collect();
 
         assert_eq!(IpNet::aggregate(&ip_nets), ip_aggs);
         assert_eq!(Ipv4Net::aggregate(&ipv4_nets), ipv4_aggs);
         assert_eq!(Ipv6Net::aggregate(&ipv6_nets), ipv6_aggs);
     }
-    
+
     #[test]
     fn test_aggregate_issue44() {
         let nets: Vec<Ipv4Net> = vec!["128.0.0.0/1".parse().unwrap()];
         assert_eq!(Ipv4Net::aggregate(&nets), nets);
 
         let nets: Vec<Ipv4Net> = vec!["0.0.0.0/1".parse().unwrap(), "128.0.0.0/1".parse().unwrap()];
-        assert_eq!(Ipv4Net::aggregate(&nets), vec!["0.0.0.0/0".parse().unwrap()]);
+        assert_eq!(
+            Ipv4Net::aggregate(&nets),
+            vec!["0.0.0.0/0".parse().unwrap()]
+        );
 
         let nets: Vec<Ipv6Net> = vec!["8000::/1".parse().unwrap()];
         assert_eq!(Ipv6Net::aggregate(&nets), nets);

--- a/src/ipnet_schemars.rs
+++ b/src/ipnet_schemars.rs
@@ -1,17 +1,21 @@
+use crate::IpNet;
 use crate::Ipv4Net;
 use crate::Ipv6Net;
-use crate::IpNet;
 
 use alloc::{
     boxed::Box,
-    string::{
-        String,
-        ToString
-    },
+    string::{String, ToString},
     vec,
 };
 
-use schemars::{JsonSchema, gen::SchemaGenerator, schema::{SubschemaValidation, Schema, SchemaObject, StringValidation, Metadata, SingleOrVec, InstanceType}};
+use schemars::{
+    gen::SchemaGenerator,
+    schema::{
+        InstanceType, Metadata, Schema, SchemaObject, SingleOrVec, StringValidation,
+        SubschemaValidation,
+    },
+    JsonSchema,
+};
 
 impl JsonSchema for Ipv4Net {
     fn schema_name() -> String {
@@ -37,7 +41,7 @@ impl JsonSchema for Ipv4Net {
                 ..Default::default()
             })),
             ..Default::default()
-        }) 
+        })
     }
 }
 impl JsonSchema for Ipv6Net {
@@ -60,11 +64,13 @@ impl JsonSchema for Ipv6Net {
             string: Some(Box::new(StringValidation {
                 max_length: Some(43),
                 min_length: None,
-                pattern: Some(r#"^[0-9A-Fa-f:\.]+\/(?:[0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$"#.to_string()),
+                pattern: Some(
+                    r#"^[0-9A-Fa-f:\.]+\/(?:[0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$"#.to_string(),
+                ),
                 ..Default::default()
             })),
             ..Default::default()
-        }) 
+        })
     }
 }
 impl JsonSchema for IpNet {
@@ -83,13 +89,11 @@ impl JsonSchema for IpNet {
                 ],
                 ..Default::default()
             })),
-            subschemas: Some(Box::new(
-                SubschemaValidation {
-                    one_of: Some(vec![Ipv4Net::json_schema(gen), Ipv6Net::json_schema(gen)]),
-                    ..Default::default()
-                }
-            )),
+            subschemas: Some(Box::new(SubschemaValidation {
+                one_of: Some(vec![Ipv4Net::json_schema(gen), Ipv6Net::json_schema(gen)]),
+                ..Default::default()
+            })),
             ..Default::default()
-        }) 
+        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! [`IpAddr`], [`Ipv4Addr`], and [`Ipv6Addr`] types already provided in
 //! Rust's standard library and align to their design to stay
 //! consistent.
-//! 
+//!
 //! The module also provides the [`IpSubnets`], [`Ipv4Subnets`], and
 //! [`Ipv6Subnets`] types for iterating over the subnets contained in
 //! an IP address range. The [`IpAddrRange`], [`Ipv4AddrRange`], and
@@ -61,7 +61,7 @@
 //!
 //! This library comes with support for [serde](https://serde.rs) but
 //! it's not enabled by default. Use the `serde` [feature] to enable.
-//! 
+//!
 //! ```toml
 //! [dependencies]
 //! ipnet = { version = "2", features = ["serde"] }
@@ -69,7 +69,7 @@
 //!
 //! For human readable formats (e.g. JSON) the `IpNet`, `Ipv4Net`, and
 //! `Ipv6Net` types will serialize to their `Display` strings.
-//! 
+//!
 //! For compact binary formats (e.g. Bincode) the `Ipv4Net` and
 //! `Ipv6Net` types will serialize to a string of 5 and 17 bytes that
 //! consist of the network address octects followed by the prefix
@@ -86,21 +86,23 @@ extern crate std;
 #[cfg_attr(test, macro_use)]
 extern crate alloc;
 
-#[cfg(feature = "serde")]
-extern crate serde;
 #[cfg(feature = "schemars")]
 extern crate schemars;
+#[cfg(feature = "serde")]
+extern crate serde;
 
-pub use self::ipext::{IpAdd, IpSub, IpBitAnd, IpBitOr, IpAddrRange, Ipv4AddrRange, Ipv6AddrRange};
-pub use self::ipnet::{IpNet, Ipv4Net, Ipv6Net, PrefixLenError, IpSubnets, Ipv4Subnets, Ipv6Subnets};
-pub use self::parser::AddrParseError;
+pub use self::ipext::{IpAdd, IpAddrRange, IpBitAnd, IpBitOr, IpSub, Ipv4AddrRange, Ipv6AddrRange};
+pub use self::ipnet::{
+    IpNet, IpSubnets, Ipv4Net, Ipv4Subnets, Ipv6Net, Ipv6Subnets, PrefixLenError,
+};
 pub use self::mask::{ip_mask_to_prefix, ipv4_mask_to_prefix, ipv6_mask_to_prefix};
+pub use self::parser::AddrParseError;
 
 mod ipext;
 mod ipnet;
-mod parser;
-mod mask;
-#[cfg(feature = "serde")]
-mod ipnet_serde;
 #[cfg(feature = "schemars")]
 mod ipnet_schemars;
+#[cfg(feature = "serde")]
+mod ipnet_serde;
+mod mask;
+mod parser;


### PR DESCRIPTION
before more functional changes land, it would be nice to format the repository according to the current rules.
this will make it easier to detect the difference between functional and stylistic/whitespace changes.