### PR TITLE
`arbitrary`/ fuzzy testing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,13 @@ std = []
 # Implements "schemars::JsonSchema". Also implies "serde".
 json = ["serde", "schemars"]
 ser_as_str = ["heapless"]
+arbitrary = ["dep:arbitrary"]
 
 [dependencies]
 serde = { package = "serde", version = "1", features = ["derive"], optional = true, default-features=false }
 schemars = { version = "0.8", optional = true }
 heapless = { version = "0", optional = true }
+arbitrary = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_test = "1"

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -48,6 +48,7 @@ use crate::mask::{ip_mask_to_prefix, ipv4_mask_to_prefix, ipv6_mask_to_prefix};
 /// assert_eq!(Ok(net.network()), "fd00::".parse());
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum IpNet {
     V4(Ipv4Net),
     V6(Ipv6Net),
@@ -81,6 +82,7 @@ pub enum IpNet {
 /// assert_eq!(Ok(net.network()), "10.1.1.0".parse());
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Ipv4Net {
     addr: Ipv4Addr,
     prefix_len: u8,
@@ -111,6 +113,7 @@ pub struct Ipv4Net {
 /// assert_eq!(Ok(net.network()), "fd00::".parse());
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Ipv6Net {
     addr: Ipv6Addr,
     prefix_len: u8,


### PR DESCRIPTION
Hey,

We use `IpNet` in a struct on which fuzzy testing is enabled via `arbitrary`. I added support as a feature and though it mmight benefit the community, something along the line of schemars.